### PR TITLE
Remove invalid name key from Fomo archived plan

### DIFF
--- a/applications/2026-07-11_fomo_labs_swe/plan.json
+++ b/applications/2026-07-11_fomo_labs_swe/plan.json
@@ -1,5 +1,4 @@
 {
-  "name": "fomo_labs_swe",
   "experiences": {
     "ezesports": "all",
     "reset-standard": "all"


### PR DESCRIPTION
## Summary
- Remove `"name": "fomo_labs_swe"` from `applications/2026-07-11_fomo_labs_swe/plan.json`
- This key was never a valid plan field — the parser rejects it as an unknown key
- The source plan at `plans/fomo_labs_swe.json` is already clean
- This is a data format repair, not a content change — the selection is identical

## Test plan
- [ ] Archived plan matches source plan: `diff plans/fomo_labs_swe.json applications/2026-07-11_fomo_labs_swe/plan.json` shows no diff
- [ ] `uv run worksisyphus validate --plan applications/2026-07-11_fomo_labs_swe/plan.json` exits 0
- [ ] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd25NP3Cv5wUPitwngfpLt