### PR TITLE
Document Bosch archive as pre-convention exception

### DIFF
--- a/applications/2026-07-09_bosch_software_engineer_ii/jd.txt
+++ b/applications/2026-07-09_bosch_software_engineer_ii/jd.txt
@@ -1,2 +1,6 @@
 Not recorded — this application predates the archive convention. Backfilled from the
-compiled PDF on 2026-07-11; the plan file and job description were never saved.
+compiled PDF on 2026-07-11; the original plan file and job description were never saved.
+
+This is the only archive without a plan.json. The plan cannot be faithfully reconstructed
+because the profile has changed since the original tailoring. This gap is accepted as a
+known historical exception.


### PR DESCRIPTION
## Summary
- Update `applications/2026-07-09_bosch_software_engineer_ii/jd.txt` with explicit documentation
  that this is the only archive without a `plan.json` and the gap is accepted
- Prevents future agents from attempting to reconstruct a plan that cannot be faithfully recovered

## Test plan
- [ ] `jd.txt` clearly documents the exception
- [ ] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd25NP3Cv5wUPitwngfpLt