### PR TITLE
Require --jd for archive, add plan/archive consistency tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,12 @@ You are operating Simon Chen's resume compiler. Given a job description, your jo
 7. **Archive.** Immediately after delivering, freeze the application:
 
    ```bash
-   uv run worksisyphus archive --plan plans/<name>.json --company <Company> [--jd <file|->] [--role <Role>] [--url <posting url>]
+   uv run worksisyphus archive --plan plans/<name>.json --company <Company> --jd <file|-> [--role <Role>] [--url <posting url>]
    ```
 
-   This creates `applications/<YYYY-MM-DD>_<plan-stem>/` with `jd.txt` (verbatim posting; save the user's pasted JD to a file first, or note "internal referral — no JD"), `plan.json` and `Simon_Chen_Resume.pdf` (frozen copies), and `meta.json` (`company`, `role`, `date`, `source_url`, `status: "applied"`). Archive immediately after tailoring: all plans share the `Simon_Chen_Resume.pdf` output, so a later tailor run overwrites it.
+   `--jd` is **required**. Before archiving, save the user's pasted JD to a file and pass its path. If there is genuinely no JD (internal referral, career fair), write a file explaining the absence (e.g. "Internal referral — no formal job description.") and pass that. The command refuses empty JD text.
+
+   This creates `applications/<YYYY-MM-DD>_<plan-stem>/` with `jd.txt` (verbatim posting), `plan.json` and `Simon_Chen_Resume.pdf` (frozen copies), and `meta.json` (`company`, `role`, `date`, `source_url`, `status: "applied"`). Archive immediately after tailoring: all plans share the `Simon_Chen_Resume.pdf` output, so a later tailor run overwrites it.
 
    Archived folders are immutable history: never modify an archived `Simon_Chen_Resume.pdf` or `plan.json` — a re-application to the same company gets a new dated folder (the command refuses to overwrite). Update only `meta.json.status` when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json`.
 
@@ -53,12 +55,18 @@ uv run worksisyphus compile                      # canonical 3-page database vie
 uv run worksisyphus index                        # list all selectable slugs
 uv run worksisyphus validate --plan <file|->     # parse + resolve a plan, no LaTeX needed
 uv run worksisyphus tailor --plan <file|->       # build the one-page PDF
-uv run worksisyphus archive --plan <file> --company <name>   # freeze an application folder
+uv run worksisyphus archive --plan <file> --company <name> --jd <file>  # freeze an application folder
 uv run python -m pytest tests/ -q               # test suite (no network, no pdflatex needed)
 uv run --with pdfminer.six python scripts/ats_check.py <pdf>   # ATS extraction check
 ```
 
 Exit codes: 0 success, 1 failure with a one-line `error: ...` on stderr. Plan validation errors name the offending slug.
+
+## Deterministic enforcement over workflow instructions
+
+When a constraint matters, enforce it in code — not in agent instructions. A CLI flag that is `required=True` can never be forgotten; a workflow step that says "remember to pass `--jd`" will eventually be skipped. Prefer compilation-level gates (argparse, validation errors, test assertions) over prose rules. If a new guardrail can be a test in `tests/test_consistency.py` or a check in a CLI command, put it there. Reserve CLAUDE.md rules for judgment calls that code cannot express (e.g. selection guardrails).
+
+When changing a schema or data format, migrate **all** existing data files — not just the source copies. Check both `plans/` and `applications/*/` for stale formats. A parser that rejects old data it once accepted is a bug if the old data wasn't migrated.
 
 ## Architecture (for code changes)
 

--- a/src/worksisyphus/archive.py
+++ b/src/worksisyphus/archive.py
@@ -34,7 +34,9 @@ def archive_application(
     folder.mkdir(parents=True)
     shutil.copy2(plan_path, folder / "plan.json")
     shutil.copy2(pdf_path, folder / "Simon_Chen_Resume.pdf")
-    (folder / "jd.txt").write_text((jd_text.strip() or "No job description recorded.") + "\n", encoding="utf-8")
+    if not jd_text.strip():
+        raise ValueError("jd_text is empty; pass the job description or a note explaining its absence.")
+    (folder / "jd.txt").write_text(jd_text.strip() + "\n", encoding="utf-8")
     meta = {"company": company, "role": role, "date": when.isoformat(), "source_url": source_url, "status": STATUSES[0]}
     (folder / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
     return folder

--- a/src/worksisyphus/archive.py
+++ b/src/worksisyphus/archive.py
@@ -27,6 +27,8 @@ def archive_application(
     """Freeze an application into applications/<date>_<plan-stem>/ and return the folder."""
     if not pdf_path.is_file():
         raise FileNotFoundError(f"{pdf_path} does not exist; run tailor before archiving.")
+    if not jd_text.strip():
+        raise ValueError("jd_text is empty; pass the job description or a note explaining its absence.")
     when = when or date.today()
     folder = applications_dir / f"{when.isoformat()}_{plan_path.stem}"
     if folder.exists():
@@ -34,8 +36,6 @@ def archive_application(
     folder.mkdir(parents=True)
     shutil.copy2(plan_path, folder / "plan.json")
     shutil.copy2(pdf_path, folder / "Simon_Chen_Resume.pdf")
-    if not jd_text.strip():
-        raise ValueError("jd_text is empty; pass the job description or a note explaining its absence.")
     (folder / "jd.txt").write_text(jd_text.strip() + "\n", encoding="utf-8")
     meta = {"company": company, "role": role, "date": when.isoformat(), "source_url": source_url, "status": STATUSES[0]}
     (folder / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -38,7 +38,7 @@ def main(argv: list[str] | None = None) -> int:
     archive_cmd = sub.add_parser("archive", help="Freeze a compiled application into applications/<date>_<name>/.")
     archive_cmd.add_argument("--plan", required=True, help="Path to the plan JSON file that built the resume.")
     archive_cmd.add_argument("--company", required=True, help="Company applied to.")
-    archive_cmd.add_argument("--jd", default="", help="Path to the job description text file, or - for stdin.")
+    archive_cmd.add_argument("--jd", required=True, help="Path to the job description text file, or - for stdin.")
     archive_cmd.add_argument("--role", default="", help="Role title, if known.")
     archive_cmd.add_argument("--url", default="", help="Posting URL, if any.")
     args = parser.parse_args(argv)
@@ -53,7 +53,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "archive":
             plan_path = Path(args.plan)
             selection = parse_plan(plan_path.read_text(encoding="utf-8"), load_profile())
-            jd_text = "" if not args.jd else _read_plan(args.jd)
+            jd_text = _read_plan(args.jd)
             folder = archive_application(
                 plan_path, PDF_DIR / f"{selection.name}.pdf", jd_text,
                 company=args.company, role=args.role, source_url=args.url,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -30,10 +30,10 @@ def test_archive_freezes_all_four_files(built) -> None:
                     "source_url": "https://acme.jobs/1", "status": "applied"}
 
 
-def test_archive_records_missing_jd(built) -> None:
+def test_archive_rejects_empty_jd(built) -> None:
     plan, pdf, apps = built
-    folder = archive_application(plan, pdf, "  ", company="Acme", when=date(2026, 7, 11), applications_dir=apps)
-    assert (folder / "jd.txt").read_text() == "No job description recorded.\n"
+    with pytest.raises(ValueError, match="jd_text is empty"):
+        archive_application(plan, pdf, "  ", company="Acme", when=date(2026, 7, 11), applications_dir=apps)
 
 
 def test_archive_is_immutable(built) -> None:

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,38 @@
+"""Lint-style tests that verify plan/archive consistency across the repo."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANS_DIR = ROOT / "plans"
+APPLICATIONS_DIR = ROOT / "applications"
+
+
+def _plan_slugs() -> set[str]:
+    return {p.stem for p in PLANS_DIR.glob("*.json") if p.stem != "example"}
+
+
+def _archive_slugs() -> set[str]:
+    return {
+        "_".join(d.name.split("_")[1:])
+        for d in APPLICATIONS_DIR.iterdir()
+        if d.is_dir()
+    }
+
+
+def test_every_plan_has_a_matching_archive() -> None:
+    orphaned = _plan_slugs() - _archive_slugs()
+    assert orphaned == set(), f"Plans without matching archives: {sorted(orphaned)}"
+
+
+def test_every_archive_has_required_files() -> None:
+    missing: list[str] = []
+    for d in sorted(APPLICATIONS_DIR.iterdir()):
+        if not d.is_dir():
+            continue
+        for name in ("jd.txt", "meta.json", "Simon_Chen_Resume.pdf"):
+            if not (d / name).is_file():
+                missing.append(f"{d.name}/{name}")
+    assert missing == [], f"Missing archive files: {missing}"

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 PLANS_DIR = ROOT / "plans"
 APPLICATIONS_DIR = ROOT / "applications"


### PR DESCRIPTION
## Summary
- **Bug 1 prevention (missing JDs):** `--jd` is now `required=True` in the archive CLI. `archive.py` raises `ValueError` on empty JD text. The silent "No job description recorded." fallback is removed — agents must save the JD to a file or write an explicit absence note.
- **Bug 2 prevention (orphaned plans):** New `tests/test_consistency.py` asserts every plan has a matching archive folder and every archive has its required files (`jd.txt`, `meta.json`, `Simon_Chen_Resume.pdf`).
- **CLAUDE.md:** New "Deterministic enforcement over workflow instructions" section — enforce constraints in code (argparse, tests, validation errors), not prose. Also documents the schema migration rule.

## Test plan
- [ ] `uv run python -m pytest tests/ -q` passes (37 tests)
- [ ] `uv run worksisyphus archive --plan plans/example.json --company Test` fails with `error: the following arguments are required: --jd`
- [ ] `test_archive_rejects_empty_jd` confirms empty JD text raises `ValueError`
- [ ] `test_every_plan_has_a_matching_archive` catches orphaned plans
- [ ] `test_every_archive_has_required_files` catches incomplete archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd25NP3Cv5wUPitwngfpLt