### PR TITLE
Add GEMINI.md instructions for Antigravity (Gemini) agents

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,72 @@
+# worksisyphus — Agent Instructions (Antigravity / Gemini)
+
+You are operating Simon Chen's resume compiler. Given a job description, your job is to find the best combination of content from `profile.json`, write a plan file, and produce a tailored one-page PDF.
+
+## Bounded rules (never violate)
+
+1. **One page.** Every resume delivered to the user must compile to exactly 1 page. The pipeline's trim loop enforces this mechanically; never bypass it, and never deliver a multi-page tailored PDF.
+2. **Jake's template formatting.** Formatting lives in `source_of_truth_resume.tex`. At build time the renderer copies its preamble verbatim, replaces only the body in memory, and never modifies the source file. Never modify the LaTeX preamble, section styles, or spacing to squeeze content in — fit is achieved by selecting less, not by shrinking margins or fonts.
+3. **Best combination for the JD.** Selection is your judgment call: read the job description, then pick the experiences, projects, bullets, and skills that best match it. Rank order in the plan is relevance order — the trim loop cuts from the bottom, so put the most JD-critical items first.
+4. **Select, propose, never write.** You choose slugs; you do not author resume content. If a JD genuinely begs for a reworded or new bullet, you may PROPOSE the exact text to the user, but you must never edit `profile.json` without their explicit approval of that specific text. This is the core guarantee of the system: a plan can omit a bullet, never corrupt one.
+
+## Selection guardrails
+
+- **Every employer-facing resume is named `Simon_Chen_Resume.pdf`** — recruiters see the filename, and it must never look auto-generated (no company slugs, no "tailored", no version suffixes). The pipeline enforces this; never rename the output. Per-application copies live in `applications/`, identified by their folder name. The 3-page canonical (`Simon_Chen_Resume_Compiled.pdf`) is the only differently-named PDF and never goes to employers.
+- **Never include a GPA** in `profile.json`, rendered TeX, or any resume output — Simon has decided it does not strengthen his profile. If a JD or application form explicitly demands a GPA, do not add it to the resume; flag it to Simon and let him handle it outside the pipeline.
+- **Never send the canonical resume to an employer.** `Simon_Chen_Resume_Compiled.pdf` (3 pages) is the database view for Simon's own reference. Employers only ever get tailored one-pagers.
+- **Persephone-first for engineering roles.** Any backend, systems, infra, performance, or quant JD ranks `persephone` as the top project unless the JD clearly contradicts it (e.g. a pure frontend or mobile role).
+- **Weak-project gate.** `fitness-tracker`, `spark-food-waste`, and `ml-marketplace` only appear when the JD directly matches them (mobile role, civic/impact org, blockchain role respectively). Never use them as filler.
+- **Personal-website gate.** `personal-website` only appears for frontend, full-stack, web-infra, and edge/serverless JDs. A portfolio site is the most common project on a new-grad resume, so it weakens any resume where `persephone` and `hermes-letters` already carry the engineering signal — never select it for quant, systems, backend, or infra roles.
+- **BU IT gate.** `bu-engineering-it` is only selected for IT/support/security-adjacent JDs, never for pure SWE roles.
+- No numeric caps on picks — the one-page constraint plus your ranking does the shaping.
+
+## Workflow for "tailor my resume to this JD"
+
+1. `uv run worksisyphus index` — see every selectable slug with full bullet text.
+2. Write `plans/<company>_<role>.json` (see `plans/example.json` for the format; order = rank).
+3. `uv run worksisyphus validate --plan plans/<name>.json` — catches unknown slugs and shows the resolved selection without compiling.
+4. `uv run worksisyphus tailor --plan plans/<name>.json` — renders, compiles, trims to one page. Output is always `resumes/Simon_Chen_Resume.pdf`, regardless of plan.
+5. ATS check: `uv run --with pdfminer.six python scripts/ats_check.py resumes/Simon_Chen_Resume.pdf` — must pass.
+6. **Deliver.** The resume is done when it compiles to exactly 1 page AND has no horizontal overflow (tailor fails mechanically on overflow) AND the ATS check passes — no user sign-off is required. Send the PDF along with what was picked, why, and exactly what the trim loop cut (if anything).
+7. **Archive.** Immediately after delivering, freeze the application:
+
+   ```bash
+   uv run worksisyphus archive --plan plans/<name>.json --company <Company> --jd <file|-> [--role <Role>] [--url <posting url>]
+   ```
+
+   `--jd` is **required**. Before archiving, save the user's pasted JD to a file and pass its path. If there is genuinely no JD (internal referral, career fair), write a file explaining the absence (e.g. "Internal referral — no formal job description.") and pass that. The command refuses empty JD text.
+
+   This creates `applications/<YYYY-MM-DD>_<plan-stem>/` with `jd.txt` (verbatim posting), `plan.json` and `Simon_Chen_Resume.pdf` (frozen copies), and `meta.json` (`company`, `role`, `date`, `source_url`, `status: "applied"`). Archive immediately after tailoring: all plans share the `Simon_Chen_Resume.pdf` output, so a later tailor run overwrites it.
+
+   Archived folders are immutable history: never modify an archived `Simon_Chen_Resume.pdf` or `plan.json` — a re-application to the same company gets a new dated folder (the command refuses to overwrite). Update only `meta.json.status` when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json`.
+
+## Editing profile.json (only with approval)
+
+- Values are trusted TeX inserted verbatim: escape `$`, `%`, `&`, `#` (`\$8K`, `75\%`), math like `$\sim$20$\mu$s` is intentional.
+- Slugs are stable identifiers — never rename a slug casually; plans reference them.
+- Every metric must be defensible in an interview. Never add a number the user didn't state.
+- Banned content (removed deliberately, do not reintroduce): piracy-adjacent tooling names (Sonarr/Radarr/Prowlarr/Jellyfin/qBittorrent/Slskd/Soulseek), fake-smelling metrics ("uptime by 15%", "100% incident resolution"), keyword-stuffed skills.
+
+## Commands & Execution Details
+
+```bash
+uv run worksisyphus compile                      # canonical 3-page database view (never for employers)
+uv run worksisyphus index                        # list all selectable slugs
+uv run worksisyphus validate --plan <file|->     # parse + resolve a plan, no LaTeX needed
+uv run worksisyphus tailor --plan <file|->       # build the one-page PDF
+uv run worksisyphus archive --plan <file> --company <name> --jd <file>  # freeze an application folder
+uv run python -m pytest tests/ -q               # test suite (no network, no pdflatex needed)
+uv run --with pdfminer.six python scripts/ats_check.py <pdf>   # ATS extraction check
+```
+
+Exit codes: 0 success, 1 failure with a one-line `error: ...` on stderr. Plan validation errors name the offending slug.
+
+## Deterministic enforcement over workflow instructions
+
+When a constraint matters, enforce it in code — not in agent instructions. A CLI flag that is `required=True` can never be forgotten; a workflow step that says "remember to pass `--jd`" will eventually be skipped. Prefer compilation-level gates (argparse, validation errors, test assertions) over prose rules. If a new guardrail can be a test in `tests/test_consistency.py` or a check in a CLI command, put it there. Reserve GEMINI.md rules for judgment calls that code cannot express (e.g. selection guardrails).
+
+When changing a schema or data format, migrate **all** existing data files — not just the source copies. Check both `plans/` and `applications/*/` for stale formats. A parser that rejects old data it once accepted is a bug if the old data wasn't migrated.
+
+## Architecture (for code changes)
+
+`profile.py` (slug-keyed database loader) → `plan.py` (plan parsing/validation) → `selection.py` (Selection model + deterministic trim order) → `renderer.py` (Jake's-template TeX, values verbatim) → `compiler.py` (pdflatex + page count) → `pipeline.py` (orchestration) → `cli.py`; `archive.py` freezes applications. Tests use a small fixture profile and an injectable fake compiler; they must keep passing without network or pdflatex.


### PR DESCRIPTION
## Summary
Adds `GEMINI.md` workspace agent instructions file, providing 1-to-1 parity with `CLAUDE.md` for Google Antigravity / Gemini agents.

- Codifies bounded rules (1-page, Jake's TeX template preservation, rank ordering, select/propose boundary).
- Details selection guardrails (`Simon_Chen_Resume.pdf` naming, GPA exclusion, canonical PDF boundaries, project selection rules).
- Outlines tailoring, ATS extraction checking, delivering, and archiving workflows.
- Documents profile editing guidelines, banned content, command execution details, deterministic enforcement, and codebase architecture.

## Verification
- Running `uv run python -m pytest tests/ -v`: All 37 tests pass.
- Verified file integrity and parity with `CLAUDE.md`.