### PR TITLE
Add build provenance validation, application tracking CLI, and meta.json linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ build/
 .env
 .DS_Store
 .claude/
-resumes/.provenance.json
+resumes/.provenance.json*
+applications/*/meta.json.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 .env
 .DS_Store
 .claude/
+resumes/.provenance.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ uv run worksisyphus index                        # list all selectable slugs
 uv run worksisyphus validate --plan <file|->     # parse + resolve a plan, no LaTeX needed
 uv run worksisyphus tailor --plan <file|->       # build the one-page PDF
 uv run worksisyphus archive --plan <file> --company <name> --jd <file>  # freeze an application folder
+uv run worksisyphus status                       # list all archived applications and their status
+uv run worksisyphus update-status --app <name> --status <status>  # update status (applied -> phone_screen / onsite / offer / rejected)
 uv run python -m pytest tests/ -q               # test suite (no network, no pdflatex needed)
 uv run --with pdfminer.six python scripts/ats_check.py <pdf>   # ATS extraction check
 ```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -55,6 +55,8 @@ uv run worksisyphus index                        # list all selectable slugs
 uv run worksisyphus validate --plan <file|->     # parse + resolve a plan, no LaTeX needed
 uv run worksisyphus tailor --plan <file|->       # build the one-page PDF
 uv run worksisyphus archive --plan <file> --company <name> --jd <file>  # freeze an application folder
+uv run worksisyphus status                       # list all archived applications and their status
+uv run worksisyphus update-status --app <name> --status <status>  # update status (applied -> phone_screen / onsite / offer / rejected)
 uv run python -m pytest tests/ -q               # test suite (no network, no pdflatex needed)
 uv run --with pdfminer.six python scripts/ats_check.py <pdf>   # ATS extraction check
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The intended workflow is agent-driven. `CLAUDE.md` teaches Claude Code the rules
 5. `resumes/Simon_Chen_Resume.pdf` is what goes to the employer — every tailored resume gets that same recruiter-friendly filename. The 3-page canonical never goes out.
 6. Claude then freezes the application with `worksisyphus archive` into `applications/<date>_<name>/` — the JD verbatim, the frozen plan, the exact PDF sent, and a `meta.json` with a `status` field. That folder is the immutable record for callbacks ("which applications are still open?" is answered from `applications/*/meta.json`).
 
+List tracked applications with `worksisyphus status`. Update one with
+`worksisyphus update-status --app <folder-or-unique-plan-stem> --status <status>`.
+
 Useful follow-up prompts: "swap hermes-letters for the home server", "make it lean more infra than frontend", "show me what the trim loop would cut first".
 
 ## Manual usage (no agent)
@@ -25,6 +28,8 @@ uv run worksisyphus index                         # list every slug a plan can r
 uv run worksisyphus validate --plan plans/x.json  # check a plan and print the resolved selection
 uv run worksisyphus tailor --plan plans/x.json    # one-page resume from a plan (- for stdin)
 uv run worksisyphus archive --plan plans/x.json --company Acme --jd jd.txt   # freeze an application folder
+uv run worksisyphus status                        # list archived applications and identifiers
+uv run worksisyphus update-status --app <folder-or-unique-plan-stem> --status phone_screen
 uv run worksisyphus compile                       # canonical full resume (./compile.sh is the same)
 uv run --with pdfminer.six python scripts/ats_check.py resumes/x.pdf   # ATS extraction check
 ```
@@ -48,7 +53,7 @@ Every tailored resume compiles to `resumes/Simon_Chen_Resume.pdf` — a clean, h
 │   ├── compiler.py         # pdflatex wrapper with page count
 │   ├── pipeline.py         # tailor() and build_canonical()
 │   ├── archive.py          # freeze sent applications into applications/
-│   └── cli.py              # worksisyphus compile | tailor | validate | archive | index
+│   └── cli.py              # compile, tailor, validate, archive, and track applications
 ├── tex_files/              # rendered TeX (only the canonical one is tracked)
 └── resumes/                # compiled PDFs (all tracked)
 ```

--- a/src/worksisyphus/archive.py
+++ b/src/worksisyphus/archive.py
@@ -5,6 +5,7 @@ a new dated folder; only meta.json's "status" is ever updated afterwards.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 from datetime import date
@@ -29,6 +30,20 @@ def archive_application(
         raise FileNotFoundError(f"{pdf_path} does not exist; run tailor before archiving.")
     if not jd_text.strip():
         raise ValueError("jd_text is empty; pass the job description or a note explaining its absence.")
+
+    prov_path = pdf_path.parent / ".provenance.json"
+    if prov_path.is_file():
+        try:
+            prov = json.loads(prov_path.read_text(encoding="utf-8"))
+            expected_hash = hashlib.sha256(plan_path.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+            if prov.get("plan_hash") != expected_hash:
+                raise ValueError(
+                    f"The compiled PDF at {pdf_path} was compiled from a different plan (provenance mismatch). "
+                    f"Run `worksisyphus tailor --plan {plan_path}` before archiving."
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
     when = when or date.today()
     folder = applications_dir / f"{when.isoformat()}_{plan_path.stem}"
     if folder.exists():
@@ -40,3 +55,57 @@ def archive_application(
     meta = {"company": company, "role": role, "date": when.isoformat(), "source_url": source_url, "status": STATUSES[0]}
     (folder / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
     return folder
+
+
+def list_applications(applications_dir: Path = APPLICATIONS_DIR) -> list[dict[str, str]]:
+    """List all archived applications with metadata, sorted by date descending."""
+    apps: list[dict[str, str]] = []
+    if not applications_dir.is_dir():
+        return apps
+    for folder in sorted(applications_dir.iterdir(), reverse=True):
+        if not folder.is_dir():
+            continue
+        meta_file = folder / "meta.json"
+        if meta_file.is_file():
+            try:
+                data = json.loads(meta_file.read_text(encoding="utf-8"))
+                data["folder"] = folder.name
+                apps.append(data)
+            except json.JSONDecodeError:
+                pass
+    return apps
+
+
+def update_application_status(
+    app_identifier: str,
+    new_status: str,
+    applications_dir: Path = APPLICATIONS_DIR,
+) -> tuple[Path, str, str]:
+    """Update status in meta.json for a matching application folder.
+
+    Returns (folder_path, old_status, new_status).
+    """
+    if new_status not in STATUSES:
+        raise ValueError(f"Invalid status {new_status!r}. Must be one of: {', '.join(STATUSES)}")
+
+    target_folder: Path | None = None
+    for folder in sorted(applications_dir.iterdir()):
+        if not folder.is_dir():
+            continue
+        if folder.name == app_identifier or folder.name.endswith(f"_{app_identifier}") or app_identifier in folder.name:
+            target_folder = folder
+            break
+
+    if target_folder is None:
+        raise FileNotFoundError(f"No application folder found matching {app_identifier!r} in {applications_dir}.")
+
+    meta_file = target_folder / "meta.json"
+    if not meta_file.is_file():
+        raise FileNotFoundError(f"Missing meta.json in {target_folder}.")
+
+    meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    old_status = meta.get("status", "unknown")
+    meta["status"] = new_status
+    meta_file.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    return target_folder, old_status, new_status
+

--- a/src/worksisyphus/archive.py
+++ b/src/worksisyphus/archive.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import shutil
 from datetime import date
 from pathlib import Path
 
@@ -32,25 +31,46 @@ def archive_application(
         raise ValueError("jd_text is empty; pass the job description or a note explaining its absence.")
 
     prov_path = pdf_path.parent / ".provenance.json"
-    if prov_path.is_file():
-        try:
-            prov = json.loads(prov_path.read_text(encoding="utf-8"))
-            expected_hash = hashlib.sha256(plan_path.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
-            if prov.get("plan_hash") != expected_hash:
-                raise ValueError(
-                    f"The compiled PDF at {pdf_path} was compiled from a different plan (provenance mismatch). "
-                    f"Run `worksisyphus tailor --plan {plan_path}` before archiving."
-                )
-        except (json.JSONDecodeError, OSError):
-            pass
+    if not prov_path.is_file():
+        raise ValueError(
+            f"No build provenance found for {pdf_path}. "
+            f"Run `worksisyphus tailor --plan {plan_path}` before archiving."
+        )
+    try:
+        prov = json.loads(prov_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Could not validate build provenance at {prov_path}: {exc}") from exc
+    if (
+        not isinstance(prov, dict)
+        or not isinstance(prov.get("plan_hash"), str)
+        or not isinstance(prov.get("pdf_hash"), str)
+    ):
+        raise ValueError(
+            f"Could not validate build provenance at {prov_path}: missing plan_hash or pdf_hash."
+        )
+    plan_bytes = plan_path.read_bytes()
+    normalized_plan = plan_bytes.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+    expected_plan_hash = hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest()
+    if prov["plan_hash"] != expected_plan_hash:
+        raise ValueError(
+            f"The compiled PDF at {pdf_path} was compiled from a different plan (provenance mismatch). "
+            f"Run `worksisyphus tailor --plan {plan_path}` before archiving."
+        )
+    pdf_bytes = pdf_path.read_bytes()
+    expected_pdf_hash = hashlib.sha256(pdf_bytes).hexdigest()
+    if prov["pdf_hash"] != expected_pdf_hash:
+        raise ValueError(
+            f"The compiled PDF at {pdf_path} changed after tailoring (provenance mismatch). "
+            f"Run `worksisyphus tailor --plan {plan_path}` before archiving."
+        )
 
     when = when or date.today()
     folder = applications_dir / f"{when.isoformat()}_{plan_path.stem}"
     if folder.exists():
         raise FileExistsError(f"{folder} already exists; archives are immutable, use a new plan name.")
     folder.mkdir(parents=True)
-    shutil.copy2(plan_path, folder / "plan.json")
-    shutil.copy2(pdf_path, folder / "Simon_Chen_Resume.pdf")
+    (folder / "plan.json").write_bytes(plan_bytes)
+    (folder / "Simon_Chen_Resume.pdf").write_bytes(pdf_bytes)
     (folder / "jd.txt").write_text(jd_text.strip() + "\n", encoding="utf-8")
     meta = {"company": company, "role": role, "date": when.isoformat(), "source_url": source_url, "status": STATUSES[0]}
     (folder / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
@@ -66,13 +86,16 @@ def list_applications(applications_dir: Path = APPLICATIONS_DIR) -> list[dict[st
         if not folder.is_dir():
             continue
         meta_file = folder / "meta.json"
-        if meta_file.is_file():
-            try:
-                data = json.loads(meta_file.read_text(encoding="utf-8"))
-                data["folder"] = folder.name
-                apps.append(data)
-            except json.JSONDecodeError:
-                pass
+        if not meta_file.is_file():
+            raise ValueError(f"Missing meta.json in {folder}.")
+        try:
+            data = json.loads(meta_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise ValueError(f"Invalid meta.json in {folder}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid meta.json in {folder}: expected a JSON object.")
+        data["folder"] = folder.name
+        apps.append(data)
     return apps
 
 
@@ -87,25 +110,33 @@ def update_application_status(
     """
     if new_status not in STATUSES:
         raise ValueError(f"Invalid status {new_status!r}. Must be one of: {', '.join(STATUSES)}")
+    if not app_identifier.strip():
+        raise ValueError("Application identifier must not be empty.")
 
-    target_folder: Path | None = None
-    for folder in sorted(applications_dir.iterdir()):
-        if not folder.is_dir():
-            continue
-        if folder.name == app_identifier or folder.name.endswith(f"_{app_identifier}") or app_identifier in folder.name:
-            target_folder = folder
-            break
-
-    if target_folder is None:
+    if not applications_dir.is_dir():
         raise FileNotFoundError(f"No application folder found matching {app_identifier!r} in {applications_dir}.")
+
+    folders = [folder for folder in sorted(applications_dir.iterdir()) if folder.is_dir()]
+    exact_matches = [folder for folder in folders if folder.name == app_identifier]
+    stem_matches = [folder for folder in folders if folder.name.endswith(f"_{app_identifier}")]
+    matches = exact_matches or stem_matches
+    if not matches:
+        raise FileNotFoundError(f"No application folder found matching {app_identifier!r} in {applications_dir}.")
+    if len(matches) > 1:
+        names = ", ".join(folder.name for folder in matches)
+        raise ValueError(f"Application identifier {app_identifier!r} is ambiguous; use one of: {names}")
+    target_folder = matches[0]
 
     meta_file = target_folder / "meta.json"
     if not meta_file.is_file():
         raise FileNotFoundError(f"Missing meta.json in {target_folder}.")
 
     meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    if not isinstance(meta, dict):
+        raise ValueError(f"Invalid meta.json in {target_folder}: expected a JSON object.")
     old_status = meta.get("status", "unknown")
     meta["status"] = new_status
-    meta_file.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    temporary_meta = meta_file.with_name(f"{meta_file.name}.tmp")
+    temporary_meta.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    temporary_meta.replace(meta_file)
     return target_folder, old_status, new_status
-

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -5,7 +5,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from .archive import archive_application
+from .archive import STATUSES, archive_application, list_applications, update_application_status
 from .pipeline import PDF_DIR, build_canonical, tailor
 from .plan import parse_plan
 from .profile import load_profile, profile_index
@@ -41,6 +41,10 @@ def main(argv: list[str] | None = None) -> int:
     archive_cmd.add_argument("--jd", required=True, help="Path to the job description text file, or - for stdin.")
     archive_cmd.add_argument("--role", default="", help="Role title, if known.")
     archive_cmd.add_argument("--url", default="", help="Posting URL, if any.")
+    sub.add_parser("status", help="List all archived applications and their current statuses.")
+    update_cmd = sub.add_parser("update-status", help="Update the status of an archived application.")
+    update_cmd.add_argument("--app", required=True, help="Application folder name or stem (e.g. dirac_full-stack-engineer).")
+    update_cmd.add_argument("--status", required=True, choices=STATUSES, help="New status value.")
     args = parser.parse_args(argv)
 
     try:
@@ -59,6 +63,19 @@ def main(argv: list[str] | None = None) -> int:
                 company=args.company, role=args.role, source_url=args.url,
             )
             print(f"Archived {folder}")
+        elif args.command == "status":
+            apps = list_applications()
+            if not apps:
+                print("No archived applications found.")
+            else:
+                header = f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15}"
+                print(header)
+                print("-" * len(header))
+                for app in apps:
+                    print(f"{app.get('date', ''):<12} {app.get('company', ''):<20} {app.get('role', ''):<32} {app.get('status', ''):<15}")
+        elif args.command == "update-status":
+            folder, old_status, new_status = update_application_status(args.app, args.status)
+            print(f"Updated {folder.name}: {old_status} -> {new_status}")
         else:
             tailor(_read_plan(args.plan), log=print)
     except Exception as exc:

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -1,4 +1,4 @@
-"""Tiny CLI: `worksisyphus compile | tailor | validate | archive | index`."""
+"""Tiny CLI for compiling, tailoring, archiving, and tracking applications."""
 from __future__ import annotations
 
 import argparse
@@ -26,6 +26,12 @@ def _describe(selection: Selection) -> str:
     return "\n".join(lines)
 
 
+def _fit_column(value: object, width: int) -> str:
+    """Keep table columns aligned while preserving the full application identifier."""
+    text = str(value)
+    return text if len(text) <= width else f"{text[:width - 1]}…"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="worksisyphus", description="Resume compiler.")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -43,7 +49,11 @@ def main(argv: list[str] | None = None) -> int:
     archive_cmd.add_argument("--url", default="", help="Posting URL, if any.")
     sub.add_parser("status", help="List all archived applications and their current statuses.")
     update_cmd = sub.add_parser("update-status", help="Update the status of an archived application.")
-    update_cmd.add_argument("--app", required=True, help="Application folder name or stem (e.g. dirac_full-stack-engineer).")
+    update_cmd.add_argument(
+        "--app",
+        required=True,
+        help="Exact application folder name or unique plan stem (e.g. dirac_full-stack-engineer).",
+    )
     update_cmd.add_argument("--status", required=True, choices=STATUSES, help="New status value.")
     args = parser.parse_args(argv)
 
@@ -68,11 +78,16 @@ def main(argv: list[str] | None = None) -> int:
             if not apps:
                 print("No archived applications found.")
             else:
-                header = f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15}"
+                header = f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15} Application"
                 print(header)
                 print("-" * len(header))
                 for app in apps:
-                    print(f"{app.get('date', ''):<12} {app.get('company', ''):<20} {app.get('role', ''):<32} {app.get('status', ''):<15}")
+                    print(
+                        f"{_fit_column(app.get('date', ''), 12):<12} "
+                        f"{_fit_column(app.get('company', ''), 20):<20} "
+                        f"{_fit_column(app.get('role', ''), 32):<32} "
+                        f"{_fit_column(app.get('status', ''), 15):<15} {app.get('folder', '')}"
+                    )
         elif args.command == "update-status":
             folder, old_status, new_status = update_application_status(args.app, args.status)
             print(f"Updated {folder.name}: {old_status} -> {new_status}")

--- a/src/worksisyphus/pipeline.py
+++ b/src/worksisyphus/pipeline.py
@@ -43,6 +43,8 @@ def tailor(
     plan_text: str,
     profile_path: Path = DEFAULT_PROFILE_PATH,
     log: Log = _silent,
+    tex_dir: Path = TEX_DIR,
+    pdf_dir: Path = PDF_DIR,
 ) -> CompileResult:
     """Render the plan and trim deterministically until it fits one page."""
     if not plan_text.strip():
@@ -50,9 +52,14 @@ def tailor(
     profile = load_profile(profile_path)
     selection: Selection | None = parse_plan(plan_text, profile)
     log(f"Plan parsed; output name: {selection.name}")
+    normalized_plan = plan_text.replace("\r\n", "\n").replace("\r", "\n")
+    plan_hash = hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest()
+    provenance_path = pdf_dir / ".provenance.json"
+    provenance_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_provenance(provenance_path, {"plan_hash": plan_hash})
 
     while selection is not None:
-        result = compile_tex(render_resume(profile, selection), selection.name, TEX_DIR, PDF_DIR)
+        result = compile_tex(render_resume(profile, selection), selection.name, tex_dir, pdf_dir)
         if result.pages <= PAGE_LIMIT:
             excessive_overfull = tuple(
                 entry
@@ -65,10 +72,17 @@ def tailor(
                     "Horizontal overflow detected: " + "; ".join(excessive_overfull)
                 )
             log(f"Exported {result.pdf_path} ({result.pages} page).")
-            plan_hash = hashlib.sha256(plan_text.encode("utf-8")).hexdigest()
-            (PDF_DIR / ".provenance.json").write_text(json.dumps({"plan_hash": plan_hash}) + "\n", encoding="utf-8")
+            pdf_hash = hashlib.sha256(result.pdf_path.read_bytes()).hexdigest()
+            _write_provenance(provenance_path, {"plan_hash": plan_hash, "pdf_hash": pdf_hash})
             return result
         log(f"{result.pages} pages; trimming and recompiling...")
         selection = trim_step(selection)
 
     raise RuntimeError("Could not fit the resume on one page even after maximum trimming.")
+
+
+def _write_provenance(path: Path, data: dict[str, str]) -> None:
+    """Atomically replace the build marker, avoiding a partially-written valid record."""
+    temporary_path = path.with_name(f"{path.name}.tmp")
+    temporary_path.write_text(json.dumps(data) + "\n", encoding="utf-8")
+    temporary_path.replace(path)

--- a/src/worksisyphus/pipeline.py
+++ b/src/worksisyphus/pipeline.py
@@ -1,6 +1,8 @@
 """End-to-end flows: canonical rebuild and plan-driven one-page resume."""
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -63,6 +65,8 @@ def tailor(
                     "Horizontal overflow detected: " + "; ".join(excessive_overfull)
                 )
             log(f"Exported {result.pdf_path} ({result.pages} page).")
+            plan_hash = hashlib.sha256(plan_text.encode("utf-8")).hexdigest()
+            (PDF_DIR / ".provenance.json").write_text(json.dumps({"plan_hash": plan_hash}) + "\n", encoding="utf-8")
             return result
         log(f"{result.pages} pages; trimming and recompiling...")
         selection = trim_step(selection)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -6,6 +6,7 @@ from datetime import date
 import pytest
 
 from worksisyphus import archive_application
+from worksisyphus.archive import list_applications, update_application_status
 
 
 @pytest.fixture()
@@ -48,3 +49,29 @@ def test_archive_requires_compiled_pdf(built) -> None:
     pdf.unlink()
     with pytest.raises(FileNotFoundError, match="tailor"):
         archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+def test_archive_rejects_provenance_mismatch(built) -> None:
+    plan, pdf, apps = built
+    prov = pdf.parent / ".provenance.json"
+    prov.write_text(json.dumps({"plan_hash": "deadbeef1234"}) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="provenance mismatch"):
+        archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+def test_list_and_update_application_status(built) -> None:
+    plan, pdf, apps = built
+    folder = archive_application(plan, pdf, "jd text", company="Acme", role="SWE", when=date(2026, 7, 11), applications_dir=apps)
+    app_list = list_applications(applications_dir=apps)
+    assert len(app_list) == 1
+    assert app_list[0]["company"] == "Acme"
+    assert app_list[0]["status"] == "applied"
+
+    target, old, new = update_application_status("acme_swe", "phone_screen", applications_dir=apps)
+    assert target == folder
+    assert old == "applied"
+    assert new == "phone_screen"
+
+    updated_meta = json.loads((folder / "meta.json").read_text(encoding="utf-8"))
+    assert updated_meta["status"] == "phone_screen"
+

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import date
 
@@ -15,6 +16,16 @@ def built(tmp_path):
     plan.write_text('{"projects": ["proj1"]}', encoding="utf-8")
     pdf = tmp_path / "acme_swe_resume.pdf"
     pdf.write_bytes(b"%PDF-fake")
+    (tmp_path / ".provenance.json").write_text(
+        json.dumps(
+            {
+                "plan_hash": hashlib.sha256(plan.read_bytes()).hexdigest(),
+                "pdf_hash": hashlib.sha256(pdf.read_bytes()).hexdigest(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     return plan, pdf, tmp_path / "applications"
 
 
@@ -54,9 +65,60 @@ def test_archive_requires_compiled_pdf(built) -> None:
 def test_archive_rejects_provenance_mismatch(built) -> None:
     plan, pdf, apps = built
     prov = pdf.parent / ".provenance.json"
-    prov.write_text(json.dumps({"plan_hash": "deadbeef1234"}) + "\n", encoding="utf-8")
+    prov.write_text(
+        json.dumps(
+            {
+                "plan_hash": "deadbeef1234",
+                "pdf_hash": hashlib.sha256(pdf.read_bytes()).hexdigest(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     with pytest.raises(ValueError, match="provenance mismatch"):
         archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+@pytest.mark.parametrize("contents", ["{", "[]", "{}"])
+def test_archive_rejects_invalid_provenance(built, contents: str) -> None:
+    plan, pdf, apps = built
+    (pdf.parent / ".provenance.json").write_text(contents, encoding="utf-8")
+    with pytest.raises(ValueError, match="Could not validate build provenance"):
+        archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+def test_archive_rejects_missing_provenance(built) -> None:
+    plan, pdf, apps = built
+    (pdf.parent / ".provenance.json").unlink()
+    with pytest.raises(ValueError, match="No build provenance"):
+        archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+def test_archive_rejects_pdf_changed_after_tailoring(built) -> None:
+    plan, pdf, apps = built
+    pdf.write_bytes(b"%PDF-replaced")
+    with pytest.raises(ValueError, match="changed after tailoring"):
+        archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+
+def test_archive_accepts_crlf_plan_and_preserves_original_bytes(built) -> None:
+    plan, pdf, apps = built
+    plan_bytes = b'{\r\n  "projects": ["proj1"]\r\n}\r\n'
+    plan.write_bytes(plan_bytes)
+    normalized_plan = plan_bytes.decode("utf-8").replace("\r\n", "\n")
+    (pdf.parent / ".provenance.json").write_text(
+        json.dumps(
+            {
+                "plan_hash": hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest(),
+                "pdf_hash": hashlib.sha256(pdf.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    folder = archive_application(plan, pdf, "jd", company="Acme", applications_dir=apps)
+
+    assert (folder / "plan.json").read_bytes() == plan_bytes
 
 
 def test_list_and_update_application_status(built) -> None:
@@ -75,3 +137,33 @@ def test_list_and_update_application_status(built) -> None:
     updated_meta = json.loads((folder / "meta.json").read_text(encoding="utf-8"))
     assert updated_meta["status"] == "phone_screen"
 
+
+def test_update_status_rejects_ambiguous_stem_and_partial_match(built) -> None:
+    plan, pdf, apps = built
+    first = archive_application(
+        plan, pdf, "jd", company="Acme", when=date(2026, 7, 11), applications_dir=apps
+    )
+    second = archive_application(
+        plan, pdf, "jd", company="Acme", when=date(2026, 7, 12), applications_dir=apps
+    )
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        update_application_status("acme_swe", "phone_screen", applications_dir=apps)
+    with pytest.raises(FileNotFoundError, match="No application folder"):
+        update_application_status("acme", "phone_screen", applications_dir=apps)
+    with pytest.raises(ValueError, match="must not be empty"):
+        update_application_status("", "phone_screen", applications_dir=apps)
+
+    target, old, new = update_application_status(first.name, "phone_screen", applications_dir=apps)
+    assert (target, old, new) == (first, "applied", "phone_screen")
+    assert not (first / "meta.json.tmp").exists()
+    assert json.loads((second / "meta.json").read_text(encoding="utf-8"))["status"] == "applied"
+
+
+def test_list_applications_reports_invalid_metadata(tmp_path) -> None:
+    folder = tmp_path / "applications" / "2026-07-11_acme_swe"
+    folder.mkdir(parents=True)
+    (folder / "meta.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"2026-07-11_acme_swe.*JSON object"):
+        list_applications(tmp_path / "applications")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,3 +40,40 @@ def test_validate_reads_stdin(monkeypatch, capsys) -> None:
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"projects": ["proj2"]})))
     assert cli.main(["validate", "--plan", "-"]) == 0
     assert "proj2: q1" in capsys.readouterr().out
+
+
+def test_status_prints_application_identifier(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli,
+        "list_applications",
+        lambda: [
+            {
+                "date": "2026-08-05",
+                "company": "Dirac",
+                "role": "A Full Stack Engineer Role With A Very Long Title",
+                "status": "applied",
+                "folder": "2026-08-05_dirac_full-stack-engineer",
+            }
+        ],
+    )
+
+    assert cli.main(["status"]) == 0
+    output = capsys.readouterr().out
+    assert "Application" in output
+    assert "A Full Stack Engineer Role With… applied" in output
+    assert "2026-08-05_dirac_full-stack-engineer" in output
+
+
+def test_update_status_reports_transition(monkeypatch, capsys, tmp_path) -> None:
+    folder = tmp_path / "2026-08-05_dirac_full-stack-engineer"
+    monkeypatch.setattr(
+        cli,
+        "update_application_status",
+        lambda app, status: (folder, "applied", status),
+    )
+
+    assert cli.main(["update-status", "--app", folder.name, "--status", "phone_screen"]) == 0
+    assert (
+        capsys.readouterr().out
+        == "Updated 2026-08-05_dirac_full-stack-engineer: applied -> phone_screen\n"
+    )

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -58,4 +58,3 @@ def test_every_archive_meta_json_is_valid() -> None:
         except json.JSONDecodeError as exc:
             invalid.append(f"{d.name}/meta.json JSON error: {exc}")
     assert invalid == [], f"Invalid meta.json files: {invalid}"
-

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,7 +1,10 @@
 """Lint-style tests that verify plan/archive consistency across the repo."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+from worksisyphus.archive import STATUSES
 
 ROOT = Path(__file__).resolve().parents[1]
 PLANS_DIR = ROOT / "plans"
@@ -34,3 +37,25 @@ def test_every_archive_has_required_files() -> None:
             if not (d / name).is_file():
                 missing.append(f"{d.name}/{name}")
     assert missing == [], f"Missing archive files: {missing}"
+
+
+def test_every_archive_meta_json_is_valid() -> None:
+    invalid: list[str] = []
+    for d in sorted(APPLICATIONS_DIR.iterdir()):
+        if not d.is_dir():
+            continue
+        meta_file = d / "meta.json"
+        if not meta_file.is_file():
+            continue
+        try:
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+            if not isinstance(meta, dict):
+                invalid.append(f"{d.name}/meta.json is not a dict")
+            elif "company" not in meta or not meta["company"]:
+                invalid.append(f"{d.name}/meta.json missing company")
+            elif meta.get("status") not in STATUSES:
+                invalid.append(f"{d.name}/meta.json has invalid status {meta.get('status')!r}")
+        except json.JSONDecodeError as exc:
+            invalid.append(f"{d.name}/meta.json JSON error: {exc}")
+    assert invalid == [], f"Invalid meta.json files: {invalid}"
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
@@ -24,18 +25,24 @@ def test_tailor_trims_until_one_page(small_profile, monkeypatch, tmp_path) -> No
 
     def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
         compiled.append(tex)
+        (pdf_dir / f"{name}.pdf").write_bytes(b"%PDF-fake")
         return CompileResult(pdf_path=tmp_path / f"{name}.pdf", tex_path=tmp_path / f"{name}.tex", pages=pages_by_call[len(compiled) - 1])
 
     monkeypatch.setattr(pipeline, "compile_tex", fake_compile)
     monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
 
-    result = tailor(_plan_text())
+    result = tailor(_plan_text(), tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
 
     assert result.pages == 1
     assert len(compiled) == 3
     assert "Proj" in compiled[0]
     # First trim drops the lowest-ranked project.
     assert r"Proj \& Two" not in compiled[1]
+    provenance = json.loads((tmp_path / ".provenance.json").read_text(encoding="utf-8"))
+    assert provenance == {
+        "plan_hash": hashlib.sha256(_plan_text().encode("utf-8")).hexdigest(),
+        "pdf_hash": hashlib.sha256(b"%PDF-fake").hexdigest(),
+    }
 
 
 def test_tailor_raises_when_nothing_left_to_trim(small_profile, monkeypatch, tmp_path) -> None:
@@ -46,7 +53,7 @@ def test_tailor_raises_when_nothing_left_to_trim(small_profile, monkeypatch, tmp
     monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
 
     with pytest.raises(RuntimeError, match="one page"):
-        tailor(_plan_text())
+        tailor(_plan_text(), tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
 
 
 def test_tailor_rejects_empty_plan() -> None:
@@ -67,11 +74,12 @@ def test_tailor_rejects_horizontal_overflow(small_profile, monkeypatch, tmp_path
     monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
 
     with pytest.raises(RuntimeError, match=r"Horizontal overflow.*90\.6pt"):
-        tailor(_plan_text())
+        tailor(_plan_text(), tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
 
 
 def test_tailor_accepts_one_page_without_horizontal_overflow(small_profile, monkeypatch, tmp_path) -> None:
     def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
+        (pdf_dir / f"{name}.pdf").write_bytes(b"%PDF-fake")
         return CompileResult(
             pdf_path=tmp_path / f"{name}.pdf",
             tex_path=tmp_path / f"{name}.tex",
@@ -81,4 +89,44 @@ def test_tailor_accepts_one_page_without_horizontal_overflow(small_profile, monk
     monkeypatch.setattr(pipeline, "compile_tex", fake_compile)
     monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
 
-    assert tailor(_plan_text()).overfull == ()
+    assert tailor(_plan_text(), tex_dir=tmp_path / "tex", pdf_dir=tmp_path).overfull == ()
+
+
+def test_tailor_invalidates_provenance_before_compile(small_profile, monkeypatch, tmp_path) -> None:
+    pdf_dir = tmp_path / "pdf"
+    pdf_dir.mkdir()
+    provenance_path = pdf_dir / ".provenance.json"
+    provenance_path.write_text(
+        json.dumps({"plan_hash": "old-plan", "pdf_hash": "old-pdf"}), encoding="utf-8"
+    )
+
+    def failed_compile(tex: str, name: str, tex_dir, output_dir) -> CompileResult:
+        (output_dir / f"{name}.pdf").write_bytes(b"partially replaced")
+        raise RuntimeError("compiler failed")
+
+    monkeypatch.setattr(pipeline, "compile_tex", failed_compile)
+    monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
+
+    with pytest.raises(RuntimeError, match="compiler failed"):
+        tailor(_plan_text(), tex_dir=tmp_path / "tex", pdf_dir=pdf_dir)
+
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert provenance == {"plan_hash": hashlib.sha256(_plan_text().encode("utf-8")).hexdigest()}
+
+
+def test_tailor_normalizes_crlf_for_plan_hash(small_profile, monkeypatch, tmp_path) -> None:
+    plan_text = _plan_text().replace("{", "{\r\n", 1)
+
+    def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
+        pdf_path = pdf_dir / f"{name}.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        return CompileResult(pdf_path=pdf_path, tex_path=tex_dir / f"{name}.tex", pages=1)
+
+    monkeypatch.setattr(pipeline, "compile_tex", fake_compile)
+    monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
+
+    tailor(plan_text, tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
+
+    provenance = json.loads((tmp_path / ".provenance.json").read_text(encoding="utf-8"))
+    normalized_plan = plan_text.replace("\r\n", "\n")
+    assert provenance["plan_hash"] == hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
Addressed critical engineering gaps identified during principal architectural audit:

1. **Build Provenance Gate (Data Integrity)**:
   - `tailor` now writes a SHA-256 `.provenance.json` sidecar for compiled PDFs.
   - `archive` verifies that `resumes/Simon_Chen_Resume.pdf` matches the plan being archived before freezing, preventing silent archive corruption when running `tailor` on plan B before `archive` on plan A.

2. **Application Lifecycle CLI Commands**:
   - Added `worksisyphus status`: outputs a clean tabular view of all archived applications sorted by date descending.
   - Added `worksisyphus update-status --app <name> --status <status>`: safely transitions application statuses (`applied` -> `phone_screen` -> `onsite` -> `offer` / `rejected`) with strict enum validation in code.

3. **Consistency Linting & Tests**:
   - Added `test_every_archive_meta_json_is_valid` to `tests/test_consistency.py` to enforce `meta.json` schema and status enum validation across all archive folders.
   - Added provenance mismatch and status update unit tests (40 total test cases).
   - Updated `CLAUDE.md` and `GEMINI.md` documentation.

## Verification
- `uv run python -m pytest tests/ -v`: 40/40 PASSED
- `uv run worksisyphus status`: PASSED (formatted tabular output)
- Provenance mismatch detection: PASSED