### PR TITLE
enhancement(evaluator): upstream GitHub API rate-limit resilience with conditional ETag caching (#21)

### DIFF
--- a/src/worksisyphus/hiring_agent.py
+++ b/src/worksisyphus/hiring_agent.py
@@ -139,8 +139,33 @@ Provide strict, objective scores with cited evidence in valid JSON format.
     return load_role(safe_slug)
 
 
+def _get_github_token() -> str | None:
+    """Retrieve GitHub token from environment or local .env file."""
+    import os
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token and token.strip():
+        return token.strip()
+    env_file = Path(".env")
+    if env_file.is_file():
+        try:
+            for line in env_file.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    k, v = line.split("=", 1)
+                    if k.strip() in ("GITHUB_TOKEN", "GH_TOKEN"):
+                        val = v.strip().strip("'\"")
+                        if val:
+                            return val
+        except Exception:
+            pass
+    return None
+
+
 def check_upstream_status() -> dict[str, Any]:
-    """Check local rubric manifest against upstream HackerRank repository."""
+    """Check local rubric manifest against upstream HackerRank repository with ETag caching and rate-limit resilience."""
     if not UPSTREAM_MANIFEST_PATH.is_file():
         return {
             "status": "untracked",
@@ -150,32 +175,72 @@ def check_upstream_status() -> dict[str, Any]:
     manifest = json.loads(UPSTREAM_MANIFEST_PATH.read_text(encoding="utf-8"))
     synced_commit = manifest.get("synced_commit", "unknown")
     upstream_repo = manifest.get("upstream_repo", "interviewstreet/hiring-agent")
+    cached_etag = manifest.get("etag")
 
-    remote_commit = None
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "worksisyphus-hiring-agent",
+    }
+    token = _get_github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if cached_etag:
+        headers["If-None-Match"] = cached_etag
+
     try:
         import requests
 
         url = f"https://api.github.com/repos/{upstream_repo}/commits/main"
-        resp = requests.get(url, timeout=3)
+        resp = requests.get(url, headers=headers, timeout=2)
+
+        if resp.status_code == 304:
+            return {
+                "status": "synced",
+                "upstream_repo": upstream_repo,
+                "local_commit": synced_commit[:7],
+                "remote_commit": synced_commit[:7],
+                "synced_date": manifest.get("synced_date"),
+                "reference_role": manifest.get("upstream_reference_role"),
+                "custom_tracks": manifest.get("custom_tracks", []),
+                "etag": cached_etag,
+                "message": "Local rubrics are up to date with HackerRank upstream (ETag verified 304 Not Modified).",
+            }
+
         if resp.status_code == 200:
-            remote_commit = resp.json().get("sha")
+            data = resp.json()
+            remote_commit = data.get("sha", "")
+            remote_etag = resp.headers.get("ETag") or cached_etag
+            is_synced = bool(
+                remote_commit and (remote_commit.startswith(synced_commit) or synced_commit.startswith(remote_commit))
+            )
+            return {
+                "status": "synced" if is_synced else "outdated",
+                "upstream_repo": upstream_repo,
+                "local_commit": synced_commit[:7],
+                "remote_commit": remote_commit[:7] if remote_commit else "unknown",
+                "synced_date": manifest.get("synced_date"),
+                "reference_role": manifest.get("upstream_reference_role"),
+                "custom_tracks": manifest.get("custom_tracks", []),
+                "etag": remote_etag,
+                "message": "Local rubrics are up to date with HackerRank upstream."
+                if is_synced
+                else f"Upstream update available ({synced_commit[:7]} -> {remote_commit[:7]}).",
+            }
+
+        if resp.status_code == 403:
+            return {
+                "status": "rate_limited",
+                "upstream_repo": upstream_repo,
+                "local_commit": synced_commit[:7],
+                "remote_commit": "rate_limited",
+                "synced_date": manifest.get("synced_date"),
+                "reference_role": manifest.get("upstream_reference_role"),
+                "custom_tracks": manifest.get("custom_tracks", []),
+                "etag": cached_etag,
+                "message": f"GitHub API rate limit reached. Tracked upstream commit: {synced_commit[:7]} (falling back to cache).",
+            }
     except Exception:
         pass
-
-    if remote_commit:
-        is_synced = remote_commit.startswith(synced_commit) or synced_commit.startswith(remote_commit)
-        return {
-            "status": "synced" if is_synced else "outdated",
-            "upstream_repo": upstream_repo,
-            "local_commit": synced_commit[:7],
-            "remote_commit": remote_commit[:7],
-            "synced_date": manifest.get("synced_date"),
-            "reference_role": manifest.get("upstream_reference_role"),
-            "custom_tracks": manifest.get("custom_tracks", []),
-            "message": "Local rubrics are up to date with HackerRank upstream."
-            if is_synced
-            else f"Upstream update available ({synced_commit[:7]} -> {remote_commit[:7]}).",
-        }
 
     return {
         "status": "cached",
@@ -185,6 +250,7 @@ def check_upstream_status() -> dict[str, Any]:
         "synced_date": manifest.get("synced_date"),
         "reference_role": manifest.get("upstream_reference_role"),
         "custom_tracks": manifest.get("custom_tracks", []),
+        "etag": cached_etag,
         "message": f"Tracked upstream commit: {synced_commit[:7]} (offline verification passed).",
     }
 

--- a/src/worksisyphus/roles/upstream_manifest.json
+++ b/src/worksisyphus/roles/upstream_manifest.json
@@ -2,6 +2,7 @@
   "upstream_repo": "interviewstreet/hiring-agent",
   "upstream_branch": "main",
   "synced_commit": "70fd3ea9aa74d8f76519ec643a99f9871003e70d",
+  "etag": "W/\"f1496fd336eecc78d4d76ea92aecd4b14c6c26754343636e9b8d8ae49fcaafd0\"",
   "synced_date": "2026-08-19T00:00:00Z",
   "upstream_reference_role": "software_engineering_intern",
   "custom_tracks": [

--- a/tests/test_hiring_agent.py
+++ b/tests/test_hiring_agent.py
@@ -106,14 +106,158 @@ def test_hackerrank_report_with_deductions() -> None:
     assert "Add more tests" in report
 
 
-def test_check_upstream_status() -> None:
+def test_check_upstream_status_304_not_modified(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
     from worksisyphus.hiring_agent import check_upstream_status
 
+    mock_resp = MagicMock()
+    mock_resp.status_code = 304
+
+    recorded_headers: dict[str, str] = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        recorded_headers.update(headers or {})
+        return mock_resp
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
     status = check_upstream_status()
-    assert "status" in status
-    assert "local_commit" in status
-    assert "custom_tracks" in status
-    assert len(status["custom_tracks"]) >= 3
+    assert status["status"] == "synced"
+    assert "If-None-Match" in recorded_headers
+    assert "304 Not Modified" in status["message"]
+    assert status["local_commit"] == "70fd3ea"
+    assert status["remote_commit"] == "70fd3ea"
+
+
+def test_check_upstream_status_200_ok_synced(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"sha": "70fd3ea9aa74d8f76519ec643a99f9871003e70d"}
+    mock_resp.headers = {"ETag": 'W/"newetag123"'}
+
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: mock_resp)
+
+    status = check_upstream_status()
+    assert status["status"] == "synced"
+    assert status["local_commit"] == "70fd3ea"
+    assert status["remote_commit"] == "70fd3ea"
+    assert status["etag"] == 'W/"newetag123"'
+
+
+def test_check_upstream_status_200_ok_outdated(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"sha": "abcdef1234567890abcdef1234567890abcdef12"}
+    mock_resp.headers = {"ETag": 'W/"outdatedetag"'}
+
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: mock_resp)
+
+    status = check_upstream_status()
+    assert status["status"] == "outdated"
+    assert status["local_commit"] == "70fd3ea"
+    assert status["remote_commit"] == "abcdef1"
+    assert "Upstream update available" in status["message"]
+
+
+def test_check_upstream_status_403_rate_limited(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: mock_resp)
+
+    status = check_upstream_status()
+    assert status["status"] == "rate_limited"
+    assert status["remote_commit"] == "rate_limited"
+    assert "rate limit reached" in status["message"]
+
+
+def test_check_upstream_status_offline_timeout(monkeypatch) -> None:
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    def fake_get(*args, **kwargs):
+        raise requests.exceptions.Timeout("Connection timed out")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    status = check_upstream_status()
+    assert status["status"] == "cached"
+    assert status["remote_commit"] == "offline"
+    assert "offline verification passed" in status["message"]
+
+
+def test_check_upstream_status_token_ingestion(monkeypatch) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 304
+
+    recorded_headers: dict[str, str] = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        recorded_headers.update(headers or {})
+        return mock_resp
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_mock_token_12345")
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    status = check_upstream_status()
+    assert status["status"] == "synced"
+    assert recorded_headers.get("Authorization") == "Bearer ghp_mock_token_12345"
+
+
+def test_check_upstream_status_env_file_token(monkeypatch, tmp_path) -> None:
+    from unittest.mock import MagicMock
+
+    import requests
+
+    from worksisyphus.hiring_agent import check_upstream_status
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("GH_TOKEN=ghp_from_dotenv_file\n", encoding="utf-8")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 304
+
+    recorded_headers: dict[str, str] = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        recorded_headers.update(headers or {})
+        return mock_resp
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    status = check_upstream_status()
+    assert status["status"] == "synced"
+    assert recorded_headers.get("Authorization") == "Bearer ghp_from_dotenv_file"
 
 
 def test_synthesize_role_rubric_and_cleanup(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Closes #21.

Implements conditional HTTP request caching via `ETag` / `If-None-Match`, optional environment token ingestion (`GITHUB_TOKEN` / `GH_TOKEN`), and resilient offline/rate-limit fallback for the HackerRank upstream evaluation sync checker.

### Key Changes
- **Conditional ETag Requests**: `check_upstream_status` in [`src/worksisyphus/hiring_agent.py`](file:///Users/adeland/worksisyphus/src/worksisyphus/hiring_agent.py) sends `If-None-Match: <etag>` using the cached ETag in [`upstream_manifest.json`](file:///Users/adeland/worksisyphus/src/worksisyphus/roles/upstream_manifest.json). GitHub responds with `304 Not Modified` (0 rate-limit penalty, instant response).
- **Token Ingestion**: Automatically detects `GITHUB_TOKEN` or `GH_TOKEN` from environment variables or local `.env` and adds `Authorization: Bearer <token>`.
- **Status Differentiation & Timeout**: Added explicit 2-second timeout and clean status categorization (`SYNCED`, `OUTDATED`, `RATE_LIMITED`, `CACHED`).
- **Comprehensive Unit Tests**: Added 7 mocked test scenarios in [`tests/test_hiring_agent.py`](file:///Users/adeland/worksisyphus/tests/test_hiring_agent.py) testing 304 Not Modified, 200 OK (synced & outdated), 403 Rate Limited, offline timeout, and token ingestion without network dependency.

### Verification
- `uv run pytest --cov=worksisyphus -q`: 110 passed, 93% total coverage.
- `uv run ruff check .`: clean.
- `uv run ruff format --check .`: clean.
- `uv run mypy src/ tests/`: 0 issues found across 32 source files.
- `uv run worksisyphus evaluate --check-upstream`: returns `SYNCED` cleanly.