### PR TITLE
feat(pipeline): provenance lock and conflict mutex for unarchived tailored resumes (#19)

### DIFF
--- a/src/worksisyphus/archive.py
+++ b/src/worksisyphus/archive.py
@@ -95,6 +95,13 @@ def archive_application(
         except Exception:
             pass
 
+    lock_path = pdf_path.parent / ".tailor.lock"
+    if lock_path.is_file():
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+
     return folder
 
 

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -41,6 +41,12 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("index", help="Print every slug a plan file can reference.")
     tailor_cmd = sub.add_parser("tailor", help="Compile a one-page resume from a plan file of slugs.")
     tailor_cmd.add_argument("--plan", required=True, help="Path to a plan JSON file, or - for stdin.")
+    tailor_cmd.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite unarchived tailored resume without warning.",
+    )
     validate_cmd = sub.add_parser("validate", help="Parse a plan and print the resolved selection; no LaTeX involved.")
     validate_cmd.add_argument("--plan", required=True, help="Path to a plan JSON file, or - for stdin.")
     archive_cmd = sub.add_parser("archive", help="Freeze a compiled application into applications/<date>_<name>/.")
@@ -321,7 +327,13 @@ def main(argv: list[str] | None = None) -> int:
                 out_path.write_text(json.dumps(best_plan, indent=2) + "\n", encoding="utf-8")
                 print(f"\nOptimal plan written to: {out_path}")
         else:
-            tailor(_read_plan(args.plan), log=print)
+            plan_name = Path(args.plan).stem if args.plan != "-" else "stdin"
+            tailor(
+                _read_plan(args.plan),
+                plan_name=plan_name,
+                force=args.force,
+                log=print,
+            )
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/src/worksisyphus/pipeline.py
+++ b/src/worksisyphus/pipeline.py
@@ -43,6 +43,8 @@ def build_canonical(profile_path: Path = DEFAULT_PROFILE_PATH, log: Log = _silen
 def tailor(
     plan_text: str,
     profile_path: Path = DEFAULT_PROFILE_PATH,
+    plan_name: str = "custom",
+    force: bool = False,
     log: Log = _silent,
     tex_dir: Path = TEX_DIR,
     pdf_dir: Path = PDF_DIR,
@@ -55,8 +57,30 @@ def tailor(
     log(f"Plan parsed; output name: {initial_selection.name}")
     normalized_plan = plan_text.replace("\r\n", "\n").replace("\r", "\n")
     plan_hash = hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest()
+
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = pdf_dir / ".tailor.lock"
+    if lock_path.is_file():
+        try:
+            lock_data = json.loads(lock_path.read_text(encoding="utf-8"))
+        except Exception:
+            lock_data = {}
+
+        if isinstance(lock_data, dict):
+            locked_plan_name = lock_data.get("plan_name", "previous_plan")
+            locked_plan_hash = lock_data.get("plan_hash", "")
+            locked_at = lock_data.get("tailored_at", "")
+
+            if locked_plan_hash and locked_plan_hash != plan_hash:
+                if not force:
+                    msg = f"Unarchived tailored resume exists for plan '{locked_plan_name}'"
+                    if locked_at:
+                        msg += f" (tailored at {locked_at})"
+                    msg += ". Run `worksisyphus archive` first, or pass `--force` to overwrite."
+                    raise RuntimeError(msg)
+                log(f"Warning: Overwriting unarchived tailored resume for '{locked_plan_name}' (--force enabled).")
+
     provenance_path = pdf_dir / ".provenance.json"
-    provenance_path.parent.mkdir(parents=True, exist_ok=True)
     _write_provenance(provenance_path, {"plan_hash": plan_hash})
 
     selection: Selection | None = initial_selection
@@ -73,6 +97,17 @@ def tailor(
             log(f"Exported {result.pdf_path} ({result.pages} page).")
             pdf_hash = hashlib.sha256(result.pdf_path.read_bytes()).hexdigest()
             _write_provenance(provenance_path, {"plan_hash": plan_hash, "pdf_hash": pdf_hash})
+
+            from datetime import UTC, datetime
+
+            now_iso = datetime.now(UTC).isoformat()
+            lock_info = {
+                "plan_name": plan_name,
+                "plan_hash": plan_hash,
+                "pdf_hash": pdf_hash,
+                "tailored_at": now_iso,
+            }
+            _write_provenance(lock_path, lock_info)
             return result
         log(f"{result.pages} pages; trimming and recompiling...")
         selection = trim_step(selection)
@@ -81,7 +116,7 @@ def tailor(
 
 
 def _write_provenance(path: Path, data: dict[str, str]) -> None:
-    """Atomically replace the build marker, avoiding a partially-written valid record."""
+    """Atomically replace the build marker or lock file, avoiding a partially-written valid record."""
     temporary_path = path.with_name(f"{path.name}.tmp")
-    temporary_path.write_text(json.dumps(data) + "\n", encoding="utf-8")
+    temporary_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     temporary_path.replace(path)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -178,3 +178,13 @@ def test_list_applications_reports_invalid_metadata(tmp_path) -> None:
 
     with pytest.raises(ValueError, match=r"2026-07-11_acme_swe.*JSON object"):
         list_applications(tmp_path / "applications")
+
+
+def test_archive_releases_tailor_lock(built) -> None:
+    plan, pdf, apps = built
+    lock_path = pdf.parent / ".tailor.lock"
+    lock_path.write_text('{"plan_name": "acme_swe"}', encoding="utf-8")
+    assert lock_path.is_file()
+
+    archive_application(plan, pdf, "the JD text", company="Acme", applications_dir=apps)
+    assert not lock_path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,3 +261,32 @@ def test_cli_optimize_command(tmp_path, capsys) -> None:
     out = capsys.readouterr().out
     assert "HACKERRANK KNAPSACK OPTIMIZER REPORT" in out
     assert out_file.is_file()
+
+
+def test_cli_tailor_invokes_pipeline_with_force(monkeypatch, tmp_path) -> None:
+    plan = _write_plan(tmp_path, {"projects": ["proj1"]})
+    recorded = {}
+
+    def fake_tailor(plan_text, plan_name="custom", force=False, log=None):
+        recorded["plan_text"] = plan_text
+        recorded["plan_name"] = plan_name
+        recorded["force"] = force
+
+    monkeypatch.setattr(cli, "tailor", fake_tailor)
+
+    assert cli.main(["tailor", "--plan", plan, "--force"]) == 0
+    assert recorded["plan_name"] == "acme_swe"
+    assert recorded["force"] is True
+
+
+def test_cli_tailor_handles_unarchived_error(monkeypatch, tmp_path, capsys) -> None:
+    plan = _write_plan(tmp_path, {"projects": ["proj1"]})
+
+    def fake_tailor(plan_text, plan_name="custom", force=False, log=None):
+        raise RuntimeError("Unarchived tailored resume exists for plan 'other_company'")
+
+    monkeypatch.setattr(cli, "tailor", fake_tailor)
+
+    assert cli.main(["tailor", "--plan", plan]) == 1
+    err = capsys.readouterr().err
+    assert "error: Unarchived tailored resume exists for plan 'other_company'" in err

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -130,3 +130,39 @@ def test_tailor_normalizes_crlf_for_plan_hash(small_profile, monkeypatch, tmp_pa
     provenance = json.loads((tmp_path / ".provenance.json").read_text(encoding="utf-8"))
     normalized_plan = plan_text.replace("\r\n", "\n")
     assert provenance["plan_hash"] == hashlib.sha256(normalized_plan.encode("utf-8")).hexdigest()
+
+
+def test_tailor_writes_lockfile_and_blocks_conflict(small_profile, monkeypatch, tmp_path) -> None:
+    def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
+        pdf_path = pdf_dir / f"{name}.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        return CompileResult(pdf_path=pdf_path, tex_path=tex_dir / f"{name}.tex", pages=1)
+
+    monkeypatch.setattr(pipeline, "compile_tex", fake_compile)
+    monkeypatch.setattr(pipeline, "load_profile", lambda _path: small_profile)
+
+    plan_a = json.dumps({"projects": ["proj1"]})
+    plan_b = json.dumps({"projects": ["proj2"]})
+
+    # 1. Tailor Plan A creates lockfile
+    tailor(plan_a, plan_name="bloomberg", tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
+    lock_file = tmp_path / ".tailor.lock"
+    assert lock_file.is_file()
+    lock_data = json.loads(lock_file.read_text(encoding="utf-8"))
+    assert lock_data["plan_name"] == "bloomberg"
+    assert lock_data["plan_hash"] == hashlib.sha256(plan_a.encode("utf-8")).hexdigest()
+
+    # 2. Re-tailoring same plan succeeds without error
+    tailor(plan_a, plan_name="bloomberg", tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
+
+    # 3. Tailoring Plan B without force raises RuntimeError
+    with pytest.raises(RuntimeError, match=r"Unarchived tailored resume exists for plan 'bloomberg'"):
+        tailor(plan_b, plan_name="citadel", tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
+
+    # 4. Tailoring Plan B with force=True succeeds and updates lockfile
+    logs: list[str] = []
+    tailor(plan_b, plan_name="citadel", force=True, log=logs.append, tex_dir=tmp_path / "tex", pdf_dir=tmp_path)
+    assert any("Overwriting unarchived tailored resume" in log for log in logs)
+    updated_lock = json.loads(lock_file.read_text(encoding="utf-8"))
+    assert updated_lock["plan_name"] == "citadel"
+    assert updated_lock["plan_hash"] == hashlib.sha256(plan_b.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
Closes #19.

Implements an ephemeral lockfile (`.tailor.lock`) and SHA-256 hash conflict mutex to prevent accidental silent overwrites of unarchived tailored resumes when switching between target job plans.

### Key Changes
- **Lock Creation in `pipeline.py`**: On successful 1-page compilation, [`tailor()`](file:///Users/adeland/worksisyphus/src/worksisyphus/pipeline.py) writes `resumes/.tailor.lock` containing the active `plan_name`, `plan_hash`, `pdf_hash`, and timestamp.
- **Pre-flight Overwrite Guard**: If a lock exists for a *different* plan and `--force` is not provided, `tailor()` aborts before compilation with an informative error message directing the user to archive first or pass `--force`.
- **Friction-Free Iteration**: Re-tailoring the same plan or modifying bullets within the current plan proceeds seamlessly without requiring `--force`.
- **Lock Release on Archival**: [`archive_application()`](file:///Users/adeland/worksisyphus/src/worksisyphus/archive.py) automatically unlinks `resumes/.tailor.lock` upon successful application freezing.
- **CLI `--force` / `-f` Flag**: Added to `worksisyphus tailor` in [`src/worksisyphus/cli.py`](file:///Users/adeland/worksisyphus/src/worksisyphus/cli.py).
- **Unit Test Coverage**: Added comprehensive test cases in [`tests/test_pipeline.py`](file:///Users/adeland/worksisyphus/tests/test_pipeline.py), [`tests/test_archive.py`](file:///Users/adeland/worksisyphus/tests/test_archive.py), and [`tests/test_cli.py`](file:///Users/adeland/worksisyphus/tests/test_cli.py).

### Verification
- `uv run pytest --cov=worksisyphus -q`: 114 passed, 93% total coverage.
- `uv run ruff check .`: clean.
- `uv run ruff format --check .`: clean.
- `uv run mypy src/ tests/`: 0 issues found across 32 source files.
- `uv run --with pdfminer.six python scripts/ats_check.py resumes/Simon_Chen_Resume.pdf`: passed.