### PR TITLE
feat(archive): same-day retry suffixes, company attempt numbers, unified resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ You are operating Simon Chen's resume compiler. Given a job description, your jo
 
 5. **Deliver.** The resume is done when `apply` succeeds (compiles to exactly 1 page AND has no horizontal overflow AND passes all quality gates: ATS, No-GPA, Banned Content, LaTeX Leaks, Content Density) — no user sign-off is required. Send the PDF along with what was picked, why, and exactly what the trim loop cut (if anything).
 
-   Application folders are immutable history: never modify an application's `Simon_Chen_Resume.pdf` or `plan.json` — a re-application to the same company gets a new dated folder (the command refuses to overwrite). Update only `meta.json.status` (and `meta.json.evaluation`, via `backfill-evals`) when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json` or `uv run worksisyphus status`.
+   Application folders are immutable history: never modify an application's `Simon_Chen_Resume.pdf` or `plan.json` — re-applying to the same company/role on the same day automatically allocates the next free `_N` suffix (`2026-08-24_google_swe_2`), never overwriting or mutating a published folder. Update only `meta.json.status` (and `meta.json.evaluation`, via `backfill-evals`) when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json` or `uv run worksisyphus status`.
 
 ## Editing profile.json (only with approval)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,7 +49,7 @@ You are operating Simon Chen's resume compiler. Given a job description, your jo
 
 5. **Deliver.** The resume is done when `apply` succeeds (compiles to exactly 1 page AND has no horizontal overflow AND passes all quality gates: ATS, No-GPA, Banned Content, LaTeX Leaks, Content Density) — no user sign-off is required. Send the PDF along with what was picked, why, and exactly what the trim loop cut (if anything).
 
-   Application folders are immutable history: never modify an application's `Simon_Chen_Resume.pdf` or `plan.json` — a re-application to the same company gets a new dated folder (the command refuses to overwrite). Update only `meta.json.status` (and `meta.json.evaluation`, via `backfill-evals`) when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json` or `uv run worksisyphus status`.
+   Application folders are immutable history: never modify an application's `Simon_Chen_Resume.pdf` or `plan.json` — re-applying to the same company/role on the same day automatically allocates the next free `_N` suffix (`2026-08-24_google_swe_2`), never overwriting or mutating a published folder. Update only `meta.json.status` (and `meta.json.evaluation`, via `backfill-evals`) when the user reports progress (`applied` → `phone_screen` / `onsite` / `offer` / `rejected`). Questions like "which applications are still open?" are answered by reading `applications/*/meta.json` or `uv run worksisyphus status`.
 
 ## Editing profile.json (only with approval)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ applications; filter with `--company <name>`). Update one with
 `worksisyphus update-status --app <folder-or-unique-stem> --status <status>`; ambiguous stems are
 rejected with the list of matching full folder names. Re-applying to the same company/role on the
 same day automatically allocates the next free `_N` suffix (`2026-08-24_acme_swe_2`).
+Known limitation: a legacy folder name that already ends in `_<digits>` can be mistaken for a
+retry ordinal in status grouping if its unsuffixed base also exists — new folders are immune
+(slugs never contain `_`).
 
 Useful follow-up prompts: "swap hermes-letters for the home server", "make it lean more infra than frontend", "show me what the trim loop would cut first".
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ The intended workflow is agent-driven. `CLAUDE.md` teaches Claude Code the rules
 5. The delivered PDF lives only at `applications/<date>_<company>_<role>/Simon_Chen_Resume.pdf`. The 3-page canonical is a local build artifact and never goes out.
 6. The application is automatically tracked in SQLite and Turso cloud with full metadata, JD text, audit logs, and the HackerRank hiring-agent score for the resume as sent.
 
-List tracked applications with `worksisyphus status`. Update one with
-`worksisyphus update-status --app <folder-or-unique-plan-stem> --status <status>`.
+List tracked applications with `worksisyphus status` (grouped per company with `App#` for repeat
+applications; filter with `--company <name>`). Update one with
+`worksisyphus update-status --app <folder-or-unique-stem> --status <status>`; ambiguous stems are
+rejected with the list of matching full folder names. Re-applying to the same company/role on the
+same day automatically allocates the next free `_N` suffix (`2026-08-24_acme_swe_2`).
 
 Useful follow-up prompts: "swap hermes-letters for the home server", "make it lean more infra than frontend", "show me what the trim loop would cut first".
 

--- a/src/worksisyphus/application.py
+++ b/src/worksisyphus/application.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import re
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Collection, Iterable
 from dataclasses import replace as dataclass_replace
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -22,8 +23,12 @@ from .profile import DEFAULT_PROFILE_PATH, Profile, load_profile
 APPLICATIONS_DIR = Path("applications")
 STATUSES = ("applied", "phone_screen", "onsite", "offer", "rejected")
 STAGING_PREFIX = ".staging-"
+TEX_BUILD_PREFIX = "worksisyphus-tex-"
 
 Log = Callable[[str], None]
+
+_APP_FOLDER_RE = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})_(?P<body>.+)$")
+_ORDINAL_TAIL_RE = re.compile(r"^(?P<base>.+)_(?P<n>\d+)$")
 
 
 def _silent(_: str) -> None:
@@ -35,6 +40,59 @@ def slugify(text: str) -> str:
     text = text.lower().strip()
     text = re.sub(r"[^\w\s-]", "", text)
     return re.sub(r"[\s_-]+", "-", text).strip("-")
+
+
+def parse_app_folder(name: str, siblings: Collection[str] = ()) -> tuple[str, str, int | None]:
+    """Split an application folder name into (date, stem, ordinal).
+
+    A trailing ``_N`` tail counts as the retry ordinal written by apply() only when N >= 2 and
+    the unsuffixed base folder exists among siblings; anything else keeps the whole body as a
+    literal stem, so legacy names that happen to end in digits stay intact.
+    """
+    match = _APP_FOLDER_RE.match(name)
+    if not match:
+        raise ValueError(f"Application folder {name!r} lacks a <YYYY-MM-DD>_ prefix.")
+    date_str, body = match["date"], match["body"]
+    tail = _ORDINAL_TAIL_RE.match(body)
+    if tail and int(tail["n"]) >= 2 and f"{date_str}_{tail['base']}" in siblings:
+        return date_str, tail["base"], int(tail["n"])
+    return date_str, body, None
+
+
+def application_sort_key(name: str, siblings: Collection[str] = ()) -> tuple[int, int, str, int]:
+    """Listing order: newest date first, then retry order within a day reads top-to-bottom."""
+    try:
+        date_str, stem, ordinal = parse_app_folder(name, siblings)
+        day = -date.fromisoformat(date_str).toordinal()
+    except ValueError:
+        # Unparsable names sink below every dated entry instead of crashing listings.
+        return (1, 0, name, 0)
+    return (0, day, stem, ordinal or 0)
+
+
+def sorted_application_names(names: Collection[str]) -> list[str]:
+    """Order application folder names newest-first; retry ordinals compare numerically."""
+    return sorted(names, key=lambda name: application_sort_key(name, siblings=names))
+
+
+def match_application_identifier(identifier: str, names: Iterable[str]) -> list[str]:
+    """Resolve an identifier against candidate names: exact match first, else unique stem match."""
+    all_names = list(names)
+    exact = [name for name in all_names if name == identifier]
+    if exact:
+        return exact
+    return [name for name in all_names if name.endswith(f"_{identifier}")]
+
+
+def _allocate_target(applications_dir: Path, base_target: Path) -> Path:
+    """Lowest free slot for a publish: the plain name first, then _2, _3, ..."""
+    taken = {entry.name for entry in applications_dir.iterdir()}
+    target = base_target
+    ordinal = 1
+    while target.name in taken:
+        ordinal += 1
+        target = base_target.parent / f"{base_target.name}_{ordinal}"
+    return target
 
 
 def apply(
@@ -61,22 +119,26 @@ def apply(
     applications_dir = applications_dir if applications_dir is not None else APPLICATIONS_DIR
     when = when or date.today()
 
-    # Deterministic naming strictly derived from company and role (#34)
+    # Deterministic naming strictly derived from company and role (#34). The underscore is the
+    # folder grammar's structural separator (it delimits the retry ordinal), so slugify must
+    # never emit one; this fails loudly instead of corrupting the namespace if that ever changes.
     comp_slug = slugify(company)
     role_slug = slugify(role) if role.strip() else "swe"
+    if "_" in comp_slug or "_" in role_slug:
+        raise ValueError(f"Slug for {company!r}/{role!r} contains '_': {comp_slug}_{role_slug}")
     app_stem = f"{comp_slug}_{role_slug}"
 
-    target_folder = applications_dir / f"{when.isoformat()}_{app_stem}"
-    if target_folder.exists():
-        raise FileExistsError(f"{target_folder} already exists; applications are immutable, use a new date or role.")
+    base_target = applications_dir / f"{when.isoformat()}_{app_stem}"
 
     active_profile = profile if profile is not None else load_profile(profile_path)
     normalized_plan = plan_text.replace("\r\n", "\n").replace("\r", "\n")
 
     # Atomic publication: stage inside applications_dir so the final publish is a same-filesystem
     # os.replace rather than a file-by-file copy that can fail halfway and leave a partial folder.
+    # LaTeX intermediates get their own temp dir so concurrent applies never clobber tex_files/.
     applications_dir.mkdir(parents=True, exist_ok=True)
     staging_dir = Path(tempfile.mkdtemp(prefix=STAGING_PREFIX, dir=applications_dir))
+    tex_build_dir = Path(tempfile.mkdtemp(prefix=TEX_BUILD_PREFIX))
     try:
         # 1. Compile directly into the isolated staging dir
         compile_result = tailor(
@@ -85,6 +147,7 @@ def apply(
             profile_path=profile_path,
             plan_name=app_stem,
             pdf_dir=staging_dir,
+            tex_dir=tex_build_dir,
             log=log,
         )
 
@@ -110,7 +173,7 @@ def apply(
         failed_gates = [g for g in gate_results if not g.passed]
         if failed_gates:
             reasons = "\n".join(f"- {g.gate_name}: {'; '.join(g.diagnostics)}" for g in failed_gates)
-            raise RuntimeError(f"Quality gate check failed for {target_folder.name}:\n{reasons}")
+            raise RuntimeError(f"Quality gate check failed for {base_target.name}:\n{reasons}")
 
         # 3b. Score the delivered resume against this JD and record it alongside the application,
         #     so every application carries the evaluation that was true when it was sent.
@@ -123,19 +186,25 @@ def apply(
         meta["evaluation"] = evaluation
         (staging_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
-        # 4. Atomic publish. Re-check the target: compilation is slow enough that a concurrent
-        #    apply could have claimed the slot since the check above, and os.replace would
-        #    silently consume an empty directory.
-        if target_folder.exists():
-            raise FileExistsError(
-                f"{target_folder} already exists; applications are immutable, use a new date or role."
-            )
-        # mkdtemp is 0700; widen to match a normally-created directory.
-        os.chmod(staging_dir, 0o755)
-        os.replace(staging_dir, target_folder)
+        # 4. Atomic publish with retry allocation. Compilation is slow enough that a concurrent
+        #    apply could claim the plain slot first; os.replace onto a non-empty directory fails
+        #    with ENOTEMPTY, so the loser re-allocates the next free suffix and retries with the
+        #    staged content it already paid for. Published folders are never mutated or consumed.
+        while True:
+            target_folder = _allocate_target(applications_dir, base_target)
+            # mkdtemp is 0700; widen to match a normally-created directory.
+            os.chmod(staging_dir, 0o755)
+            try:
+                os.replace(staging_dir, target_folder)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.ENOTEMPTY, errno.EEXIST):
+                    raise
     except BaseException:
         shutil.rmtree(staging_dir, ignore_errors=True)
         raise
+    finally:
+        shutil.rmtree(tex_build_dir, ignore_errors=True)
 
     compile_result = dataclass_replace(compile_result, pdf_path=target_folder / "Simon_Chen_Resume.pdf")
 
@@ -265,14 +334,16 @@ def _sync_cloud(log: Log) -> bool:
 
 
 def list_applications(applications_dir: Path | None = None) -> list[dict[str, str]]:
-    """List all applications with metadata, sorted by date descending."""
+    """List all applications with metadata, newest date first (retry order within a day)."""
     applications_dir = applications_dir if applications_dir is not None else APPLICATIONS_DIR
     apps: list[dict[str, str]] = []
     if not applications_dir.is_dir():
         return apps
-    for folder in sorted(applications_dir.iterdir(), reverse=True):
-        if not folder.is_dir() or folder.name.startswith("."):
-            continue
+    entries = [entry for entry in applications_dir.iterdir() if entry.is_dir() and not entry.name.startswith(".")]
+    names = sorted_application_names([entry.name for entry in entries])
+    by_name = {entry.name: entry for entry in entries}
+    for name in names:
+        folder = by_name[name]
         meta_file = folder / "meta.json"
         if not meta_file.is_file():
             raise ValueError(f"Missing meta.json in {folder}; the application folder is incomplete.")
@@ -299,18 +370,21 @@ def resolve_application_folder(
     if not applications_dir.is_dir():
         raise FileNotFoundError(f"No application folder found matching {app_identifier!r} in {applications_dir}.")
 
-    folders = [
-        folder for folder in sorted(applications_dir.iterdir()) if folder.is_dir() and not folder.name.startswith(".")
+    names = [
+        folder.name
+        for folder in sorted(applications_dir.iterdir())
+        if folder.is_dir() and not folder.name.startswith(".")
     ]
-    exact_matches = [folder for folder in folders if folder.name == app_identifier]
-    stem_matches = [folder for folder in folders if folder.name.endswith(f"_{app_identifier}")]
-    matches = exact_matches or stem_matches
+    matches = match_application_identifier(app_identifier, names)
     if not matches:
         raise FileNotFoundError(f"No application folder found matching {app_identifier!r} in {applications_dir}.")
     if len(matches) > 1:
-        names = ", ".join(folder.name for folder in matches)
-        raise ValueError(f"Application identifier {app_identifier!r} is ambiguous; use one of: {names}")
-    return matches[0]
+        listed = "\n".join(f"  {name}" for name in matches)
+        raise ValueError(
+            f"Application identifier {app_identifier!r} is ambiguous ({len(matches)} matches):\n{listed}\n"
+            "Re-run with one of the full folder names above."
+        )
+    return applications_dir / matches[0]
 
 
 def update_application_status(

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -30,14 +30,19 @@ def _describe(selection: Selection) -> str:
     return "\n".join(lines)
 
 
-def _latest_application_pdf() -> Path | None:
+def _latest_application_pdf(applications_dir: Path | None = None) -> Path | None:
     """The most recent delivered resume. Applications are the only place a delivered PDF lives."""
-    apps = list_applications()
+    from .application import APPLICATIONS_DIR
+
+    # Resolve through the module so tests (and callers) can redirect applications/.
+    resolved_dir = applications_dir if applications_dir is not None else APPLICATIONS_DIR
+    apps = list_applications(applications_dir=resolved_dir)
     if not apps:
         return None
+    names = {app["folder"] for app in apps}
 
     def recency(app: dict[str, str]) -> tuple[int, int]:
-        date_str, _, ordinal = parse_app_folder(app["folder"], siblings={a["folder"] for a in apps})
+        date_str, _, ordinal = parse_app_folder(app["folder"], siblings=names)
         try:
             day = date.fromisoformat(date_str).toordinal()
         except ValueError:
@@ -45,10 +50,7 @@ def _latest_application_pdf() -> Path | None:
         return (day, ordinal or 0)
 
     newest = max(apps, key=recency)
-    # Resolve the dir through the module so tests (and callers) can redirect applications/.
-    from .application import APPLICATIONS_DIR as _apps_dir
-
-    return _apps_dir / newest["folder"] / "Simon_Chen_Resume.pdf"
+    return resolved_dir / newest["folder"] / "Simon_Chen_Resume.pdf"
 
 
 def _fit_column(value: object, width: int) -> str:

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -207,9 +207,7 @@ def main(argv: list[str] | None = None) -> int:
                     attempts[key] = attempts.get(key, 0) + 1
                     app["attempt"] = str(attempts[key])
 
-                header = (
-                    f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15} {'App#':<5} Application"
-                )
+                header = f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15} {'App#':<5} Application"
                 print(header)
                 print("-" * len(header))
                 for app in apps:

--- a/src/worksisyphus/cli.py
+++ b/src/worksisyphus/cli.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import date
 from pathlib import Path
 
-from .application import APPLICATIONS_DIR, STATUSES, list_applications, update_application_status
+from .application import STATUSES, list_applications, parse_app_folder, slugify, update_application_status
 from .application import apply as apply_app
 from .pipeline import PREVIEW_DIR, build_canonical, tailor
 from .plan import parse_plan
@@ -34,7 +35,20 @@ def _latest_application_pdf() -> Path | None:
     apps = list_applications()
     if not apps:
         return None
-    return APPLICATIONS_DIR / apps[0]["folder"] / "Simon_Chen_Resume.pdf"
+
+    def recency(app: dict[str, str]) -> tuple[int, int]:
+        date_str, _, ordinal = parse_app_folder(app["folder"], siblings={a["folder"] for a in apps})
+        try:
+            day = date.fromisoformat(date_str).toordinal()
+        except ValueError:
+            day = 0
+        return (day, ordinal or 0)
+
+    newest = max(apps, key=recency)
+    # Resolve the dir through the module so tests (and callers) can redirect applications/.
+    from .application import APPLICATIONS_DIR as _apps_dir
+
+    return _apps_dir / newest["folder"] / "Simon_Chen_Resume.pdf"
 
 
 def _fit_column(value: object, width: int) -> str:
@@ -74,12 +88,17 @@ def main(argv: list[str] | None = None) -> int:
     apply_cmd.add_argument("--no-sync", action="store_true", help="Skip Turso cloud sync.")
     validate_cmd = sub.add_parser("validate", help="Parse a plan and print the resolved selection; no LaTeX involved.")
     validate_cmd.add_argument("--plan", required=True, help="Path to a plan JSON file, or - for stdin.")
-    sub.add_parser("status", help="List all applications and their current statuses.")
+    status_cmd = sub.add_parser("status", help="List all applications and their current statuses.")
+    status_cmd.add_argument(
+        "--company",
+        default=None,
+        help="Case-insensitive substring filter on the company name.",
+    )
     update_cmd = sub.add_parser("update-status", help="Update the status of an application.")
     update_cmd.add_argument(
         "--app",
         required=True,
-        help="Exact application folder name or unique plan stem (e.g. dirac_full-stack-engineer).",
+        help="Full application folder name or unique stem; ambiguous stems are rejected with the list of matches.",
     )
     update_cmd.add_argument("--status", required=True, choices=STATUSES, help="New status value.")
     update_cmd.add_argument("--no-sync", action="store_true", help="Skip Turso cloud sync.")
@@ -172,18 +191,34 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Application created: {folder}")
         elif args.command == "status":
             apps = list_applications()
+            if args.company:
+                needle = args.company.lower()
+                apps = [app for app in apps if needle in app.get("company", "").lower()]
             if not apps:
                 print("No applications found.")
             else:
-                header = f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15} Application"
+                # App# = nth application to the same company, oldest first; blank for singletons.
+                # Same-day siblings are distinct attempts and get their own number.
+                attempts: dict[str, int] = {}
+                for app in reversed(apps):
+                    key = slugify(app.get("company", ""))
+                    attempts[key] = attempts.get(key, 0) + 1
+                    app["attempt"] = str(attempts[key])
+
+                header = (
+                    f"{'Date':<12} {'Company':<20} {'Role':<32} {'Status':<15} {'App#':<5} Application"
+                )
                 print(header)
                 print("-" * len(header))
                 for app in apps:
+                    key = slugify(app.get("company", ""))
+                    attempt_cell = f"#{app['attempt']}" if attempts[key] > 1 else ""
                     print(
                         f"{_fit_column(app.get('date', ''), 12):<12} "
                         f"{_fit_column(app.get('company', ''), 20):<20} "
                         f"{_fit_column(app.get('role', ''), 32):<32} "
-                        f"{_fit_column(app.get('status', ''), 15):<15} {app.get('folder', '')}"
+                        f"{_fit_column(app.get('status', ''), 15):<15} "
+                        f"{attempt_cell:<5} {app.get('folder', '')}"
                     )
         elif args.command == "update-status":
             folder, old_status, new_status = update_application_status(
@@ -324,7 +359,7 @@ def main(argv: list[str] | None = None) -> int:
                     raise FileNotFoundError(f"Missing jd.txt in {app_path}")
                 jd_text = jd_file.read_text(encoding="utf-8")
                 pdf_path = app_path / "Simon_Chen_Resume.pdf"
-                role_label = args.app
+                role_label = app_path.name
                 if pdf_path.is_file():
                     resume_text = check_pdf_ats(pdf_path, name=profile.contact.name).text if args.hackerrank else ""
             else:

--- a/src/worksisyphus/db.py
+++ b/src/worksisyphus/db.py
@@ -448,9 +448,10 @@ def seed_database(
                 log_audit_event(conn, entity_type, entity_id, ACTION_DELETE, commit=False)
 
     # 6. Applications (merge from applications_dir without clobbering existing DB records)
+    seen_applications: set[str] = set()
     if applications_dir.is_dir():
         for d in sorted(applications_dir.iterdir()):
-            if not d.is_dir():
+            if not d.is_dir() or d.name.startswith("."):
                 continue
             meta_file = d / "meta.json"
             jd_file = d / "jd.txt"
@@ -483,6 +484,7 @@ def seed_database(
                     evaluation_json,
                 ),
             )
+            seen_applications.add(d.name)
             _log_change(
                 conn,
                 prior_applications,
@@ -502,6 +504,13 @@ def seed_database(
                 action_new=ACTION_APPLY,
                 metadata=meta,
             )
+
+    # 6b. Ghost rows. A DB application whose folder no longer exists on disk (partial restore,
+    #     manual removal) would otherwise survive every reseed and trip the FS<->DB consistency
+    #     test; delete it inside the same transaction, with an audit event like other removals.
+    for removed_id in sorted(set(prior_applications) - seen_applications):
+        conn.execute("DELETE FROM applications WHERE id = ?", (removed_id,))
+        log_audit_event(conn, "application", removed_id, ACTION_DELETE, commit=False)
 
     conn.commit()
 
@@ -638,11 +647,14 @@ def save_application_to_db(
 
 def list_applications_from_db(conn: sqlite3.Connection) -> list[dict[str, str]]:
     """Return all applications from DB ordered by date descending."""
-    cur = conn.execute(
-        "SELECT id, company, role, date, source_url, status FROM applications ORDER BY date DESC, id DESC"
-    )
+    from .application import sorted_application_names
+
+    cur = conn.execute("SELECT id, company, role, date, source_url, status FROM applications")
+    rows = cur.fetchall()
+    order = {name: index for index, name in enumerate(sorted_application_names([row[0] for row in rows]))}
+    rows.sort(key=lambda row: order[row[0]])
     results: list[dict[str, str]] = []
-    for app_id, company, role, dt, url, status in cur.fetchall():
+    for app_id, company, role, dt, url, status in rows:
         results.append(
             {
                 "folder": app_id,
@@ -660,16 +672,23 @@ def update_application_status_in_db(
     conn: sqlite3.Connection, app_identifier: str, new_status: str
 ) -> tuple[str, str, str]:
     """Update status in DB and record an append-only audit event."""
-    cur = conn.execute(
-        "SELECT id, status FROM applications WHERE id = ? OR id LIKE ?", (app_identifier, f"%_{app_identifier}")
-    )
-    rows = cur.fetchall()
-    if not rows:
+    # Resolve with the exact same grammar as resolve_application_folder on disk (exact match,
+    # else unique stem suffix). SQL LIKE would treat _ and % in identifiers as wildcards and
+    # silently disagree with the filesystem resolver.
+    from .application import match_application_identifier
+
+    rows = conn.execute("SELECT id, status FROM applications").fetchall()
+    matches = match_application_identifier(app_identifier, [row[0] for row in rows])
+    if not matches:
         raise FileNotFoundError(f"No application found matching {app_identifier!r}.")
-    if len(rows) > 1:
-        names = ", ".join(r[0] for r in rows)
-        raise ValueError(f"Application identifier {app_identifier!r} is ambiguous; matches: {names}")
-    app_id, old_status = rows[0]
+    if len(matches) > 1:
+        listed = "\n".join(f"  {name}" for name in matches)
+        raise ValueError(
+            f"Application identifier {app_identifier!r} is ambiguous ({len(matches)} matches):\n{listed}\n"
+            "Re-run with one of the full folder names above."
+        )
+    app_id = matches[0]
+    old_status = next(status for row_id, status in rows if row_id == app_id)
     conn.execute(
         "UPDATE applications SET status = ?, updated_at = (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) WHERE id = ?",
         (new_status, app_id),

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -593,7 +593,11 @@ def test_backfill_is_idempotent_and_respects_overwrite(small_profile, monkeypatc
 
 def test_parse_app_folder_handles_legacy_names() -> None:
     # Legacy pre-#34 stems with literal underscores and hyphen-digits are never ordinals.
-    assert parse_app_folder("2026-07-09_bosch_software_engineer_ii") == ("2026-07-09", "bosch_software_engineer_ii", None)
+    assert parse_app_folder("2026-07-09_bosch_software_engineer_ii") == (
+        "2026-07-09",
+        "bosch_software_engineer_ii",
+        None,
+    )
     assert parse_app_folder("2026-08-18_bloomberg_software-engineer-2027") == (
         "2026-08-18",
         "bloomberg_software-engineer-2027",

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import json
 from datetime import date
+from pathlib import Path
 
 import pytest
 
 from worksisyphus import CompileResult, apply
-from worksisyphus.application import list_applications, resolve_application_folder, slugify, update_application_status
+from worksisyphus.application import (
+    list_applications,
+    parse_app_folder,
+    resolve_application_folder,
+    slugify,
+    update_application_status,
+)
 from worksisyphus.ats import ATSCheckResult
 from worksisyphus.gates import GateResult
 
@@ -234,9 +241,141 @@ def test_apply_rejects_empty_plan(tmp_path) -> None:
         )
 
 
-def test_apply_is_immutable(small_profile, monkeypatch, tmp_path) -> None:
+def _fake_compile_factory():
     def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
         pdf_path = pdf_dir / f"{name}.pdf"
+        pdf_path.write_bytes(b"%PDF-fake")
+        return CompileResult(pdf_path=pdf_path, tex_path=tex_dir / f"{name}.tex", pages=1)
+
+    return fake_compile
+
+
+def _patch_apply_pipeline(monkeypatch) -> None:
+    import worksisyphus.application as app_module
+    import worksisyphus.pipeline as pipe_module
+
+    monkeypatch.setattr(pipe_module, "compile_tex", _fake_compile_factory())
+    monkeypatch.setattr(
+        app_module,
+        "run_resume_gates",
+        lambda *a, **kw: ((GateResult("ATS", True, ()),), ATSCheckResult(True, (), 1, 100, "text")),
+    )
+
+
+def test_apply_same_day_second_attempt_allocates_suffix(small_profile, monkeypatch, tmp_path) -> None:
+    _patch_apply_pipeline(monkeypatch)
+
+    plan_text = json.dumps({"experiences": {"org-a": ["a1"]}})
+    apps_dir = tmp_path / "applications"
+    kwargs = dict(
+        plan_text=plan_text,
+        jd_text="JD text",
+        company="Acme",
+        role="SWE",
+        when=date(2026, 8, 20),
+        profile=small_profile,
+        applications_dir=apps_dir,
+        sync_cloud=False,
+    )
+
+    first, _, _ = apply(**kwargs)
+    second, _, _ = apply(**kwargs)
+    third, _, _ = apply(**kwargs)
+
+    assert [folder.name for folder in (first, second, third)] == [
+        "2026-08-20_acme_swe",
+        "2026-08-20_acme_swe_2",
+        "2026-08-20_acme_swe_3",
+    ]
+    for folder in (first, second, third):
+        assert (folder / "meta.json").is_file()
+        assert json.loads((folder / "meta.json").read_text(encoding="utf-8"))["status"] == "applied"
+
+
+def test_apply_never_mutates_a_published_folder(small_profile, monkeypatch, tmp_path) -> None:
+    _patch_apply_pipeline(monkeypatch)
+
+    plan_text = json.dumps({"experiences": {"org-a": ["a1"]}})
+    apps_dir = tmp_path / "applications"
+
+    first, _, _ = apply(
+        plan_text=plan_text,
+        jd_text="JD text",
+        company="Acme",
+        role="SWE",
+        when=date(2026, 8, 20),
+        profile=small_profile,
+        applications_dir=apps_dir,
+        sync_cloud=False,
+    )
+    before = {path.name: path.read_bytes() for path in sorted(first.iterdir())}
+
+    apply(
+        plan_text=plan_text,
+        jd_text="JD text",
+        company="Acme",
+        role="SWE",
+        when=date(2026, 8, 20),
+        profile=small_profile,
+        applications_dir=apps_dir,
+        sync_cloud=False,
+    )
+
+    after = {path.name: path.read_bytes() for path in sorted(first.iterdir())}
+    assert before == after
+
+
+def test_apply_retries_next_suffix_when_target_claimed_concurrently(small_profile, monkeypatch, tmp_path) -> None:
+    import errno as errno_module
+
+    import worksisyphus.application as app_module
+
+    _patch_apply_pipeline(monkeypatch)
+    apps_dir = tmp_path / "applications"
+
+    # Simulate a concurrent apply claiming ..._swe_2 between allocation and publish.
+    original_allocate = app_module._allocate_target
+    real_replace = app_module.os.replace
+    occupied = apps_dir / "2026-08-20_acme_swe_2"
+    allocations = {"n": 0}
+
+    def racy_allocate(applications_dir, base_target):
+        target = original_allocate(applications_dir, base_target)
+        allocations["n"] += 1
+        if allocations["n"] == 2 and target == occupied and not occupied.exists():
+            occupied.mkdir(parents=True)
+            (occupied / "meta.json").write_text("{}", encoding="utf-8")
+        return target
+
+    def replace(src, dst):
+        if Path(dst) == occupied and occupied.exists():
+            raise OSError(errno_module.ENOTEMPTY, "Directory not empty")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(app_module, "_allocate_target", racy_allocate)
+    monkeypatch.setattr(app_module.os, "replace", replace)
+
+    common = dict(
+        plan_text=json.dumps({"experiences": {"org-a": ["a1"]}}),
+        jd_text="JD text",
+        company="Acme",
+        role="SWE",
+        when=date(2026, 8, 20),
+        profile=small_profile,
+        applications_dir=apps_dir,
+        sync_cloud=False,
+    )
+    apply(**common)  # claims the plain slot
+    folder, _, _ = apply(**common)
+    assert folder.name == "2026-08-20_acme_swe_3"
+
+
+def test_apply_uses_private_tex_directory(small_profile, monkeypatch, tmp_path) -> None:
+    seen_tex_dirs: list[Path] = []
+
+    def fake_compile(tex: str, name: str, tex_dir, pdf_dir) -> CompileResult:
+        seen_tex_dirs.append(Path(tex_dir))
+        pdf_path = Path(pdf_dir) / f"{name}.pdf"
         pdf_path.write_bytes(b"%PDF-fake")
         return CompileResult(pdf_path=pdf_path, tex_path=tex_dir / f"{name}.tex", pages=1)
 
@@ -250,31 +389,28 @@ def test_apply_is_immutable(small_profile, monkeypatch, tmp_path) -> None:
         lambda *a, **kw: ((GateResult("ATS", True, ()),), ATSCheckResult(True, (), 1, 100, "text")),
     )
 
-    plan_text = json.dumps({"experiences": {"org-a": ["a1"]}})
     apps_dir = tmp_path / "applications"
-
     apply(
-        plan_text=plan_text,
-        jd_text="JD text",
+        plan_text=json.dumps({"experiences": {"org-a": ["a1"]}}),
+        jd_text="jd",
         company="Acme",
         role="SWE",
-        when=date(2026, 8, 20),
+        when=date(2026, 7, 11),
         profile=small_profile,
         applications_dir=apps_dir,
         sync_cloud=False,
     )
 
-    with pytest.raises(FileExistsError, match="immutable"):
-        apply(
-            plan_text=plan_text,
-            jd_text="JD text",
-            company="Acme",
-            role="SWE",
-            when=date(2026, 8, 20),
-            profile=small_profile,
-            applications_dir=apps_dir,
-            sync_cloud=False,
-        )
+    assert len(seen_tex_dirs) == 1
+    build_dir = seen_tex_dirs[0]
+    assert build_dir.name.startswith(app_module.TEX_BUILD_PREFIX)
+    assert Path(build_dir).anchor != "" and "tex_files" not in build_dir.parts
+    assert not build_dir.exists()  # cleaned up after the run
+
+
+def test_slugify_never_emits_underscore_separator() -> None:
+    for raw in ("SWE 2", "SDE_2", "Acme Corp.", "23andMe", "C++ Developer"):
+        assert "_" not in slugify(raw), raw
 
 
 def test_list_and_update_application_status(small_profile, monkeypatch, tmp_path) -> None:
@@ -453,3 +589,60 @@ def test_backfill_is_idempotent_and_respects_overwrite(small_profile, monkeypatc
 
     # ...unless explicitly told to re-score.
     assert len(backfill_evaluations(applications_dir=apps, overwrite=True)) == 1
+
+
+def test_parse_app_folder_handles_legacy_names() -> None:
+    # Legacy pre-#34 stems with literal underscores and hyphen-digits are never ordinals.
+    assert parse_app_folder("2026-07-09_bosch_software_engineer_ii") == ("2026-07-09", "bosch_software_engineer_ii", None)
+    assert parse_app_folder("2026-08-18_bloomberg_software-engineer-2027") == (
+        "2026-08-18",
+        "bloomberg_software-engineer-2027",
+        None,
+    )
+
+
+def test_parse_app_folder_ordinal_requires_the_base_sibling() -> None:
+    siblings = ["2026-08-24_google_swe", "2026-08-24_google_swe_2", "2026-08-24_google_swe_10"]
+    assert parse_app_folder("2026-08-24_google_swe_2", siblings) == ("2026-08-24", "google_swe", 2)
+    assert parse_app_folder("2026-08-24_google_swe_10", siblings) == ("2026-08-24", "google_swe", 10)
+    # Without its base on disk the tail stays literal; no lineage is invented.
+    assert parse_app_folder("2027-01-01_x_y_2") == ("2027-01-01", "x_y_2", None)
+
+
+def test_parse_app_folder_requires_a_date_prefix() -> None:
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        parse_app_folder("not-a-date")
+
+
+def test_resolve_lists_each_ambiguous_match_on_its_own_line(tmp_path) -> None:
+    for day in ("02", "08"):
+        folder = tmp_path / "applications" / f"2026-08-{day}_google_data-engineer"
+        folder.mkdir(parents=True)
+        (folder / "meta.json").write_text(json.dumps({"company": "Google", "status": "applied"}), encoding="utf-8")
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_application_folder("google_data-engineer", applications_dir=tmp_path / "applications")
+    lines = excinfo.value.args[0].splitlines()
+    assert any("2026-08-02_google_data-engineer" in line for line in lines)
+    assert any("2026-08-08_google_data-engineer" in line for line in lines)
+
+
+def test_list_applications_orders_newest_first_then_retry_order(tmp_path) -> None:
+    apps_dir = tmp_path / "applications"
+    for name in (
+        "2026-08-20_acme_swe",
+        "2026-08-24_google_swe_2",
+        "2026-08-24_google_swe",
+        "2026-08-24_google_swe_10",
+    ):
+        folder = apps_dir / name
+        folder.mkdir(parents=True)
+        (folder / "meta.json").write_text(json.dumps({"company": "Co", "status": "applied"}), encoding="utf-8")
+
+    order = [app["folder"] for app in list_applications(applications_dir=apps_dir)]
+    assert order == [
+        "2026-08-24_google_swe",
+        "2026-08-24_google_swe_2",
+        "2026-08-24_google_swe_10",
+        "2026-08-20_acme_swe",
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,7 +195,8 @@ def test_cli_evaluate_with_app(tmp_path, capsys, monkeypatch, delivered_pdf) -> 
     ret = cli.main(["evaluate", "--app", "testco_swe"])
     assert ret == 0
     out = capsys.readouterr().out
-    assert "RESUME EVALUATION REPORT: TESTCO_SWE" in out
+    # The report is labeled with the resolved folder name, not the raw identifier.
+    assert "RESUME EVALUATION REPORT: 2026-08-18_TESTCO_SWE" in out
 
 
 def test_cli_evaluate_missing_jd_error(capsys, delivered_pdf) -> None:
@@ -304,3 +305,54 @@ def test_cli_apply_with_optimizer(monkeypatch, tmp_path, capsys) -> None:
     assert "ATS check: passed" in out
     assert recorded["company"] == "Primitive"
     assert "projects" in recorded["plan_text"]
+
+
+def _write_app_folder(apps_dir, name, company, status="applied"):
+    folder = apps_dir / name
+    folder.mkdir(parents=True)
+    (folder / "meta.json").write_text(json.dumps({"company": company, "status": status}), encoding="utf-8")
+    (folder / "Simon_Chen_Resume.pdf").write_bytes(b"%PDF-fake")
+    return folder
+
+
+def test_status_numbers_repeat_companies_and_filters_by_company(tmp_path, capsys, monkeypatch) -> None:
+    from worksisyphus import application
+
+    apps_dir = tmp_path / "applications"
+    _write_app_folder(apps_dir, "2026-08-18_bloomberg_swe", "Bloomberg", status="rejected")
+    _write_app_folder(apps_dir, "2027-01-10_bloomberg_swe", "Bloomberg")
+    _write_app_folder(apps_dir, "2026-07-19_dirac_full-stack-engineer", "Dirac")
+
+    monkeypatch.setattr(application, "APPLICATIONS_DIR", apps_dir)
+
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "#1" in out and "#2" in out
+    # Singleton companies carry no attempt noise; the retry story reads top-to-bottom per day.
+    bloomberg_rows = [line for line in out.splitlines() if "bloomberg" in line]
+    assert len(bloomberg_rows) == 2
+    assert bloomberg_rows[0].index("#2") < bloomberg_rows[0].index("2027-01-10_bloomberg_swe")
+    dirac_line = next(line for line in out.splitlines() if "dirac" in line)
+    assert "#" not in dirac_line.split("Application")[0]
+
+    capsys.readouterr()
+    assert cli.main(["status", "--company", "bloom"]) == 0
+    filtered = capsys.readouterr().out
+    assert "dirac" not in filtered and filtered.count("bloomberg") == 2
+
+    capsys.readouterr()
+    assert cli.main(["status", "--company", "zzz"]) == 0
+    assert "No applications found." in capsys.readouterr().out
+
+
+def test_latest_application_pdf_picks_the_true_latest(tmp_path, monkeypatch) -> None:
+    from worksisyphus import application
+
+    apps_dir = tmp_path / "applications"
+    _write_app_folder(apps_dir, "2026-08-24_google_swe", "Google")
+    latest = _write_app_folder(apps_dir, "2026-08-24_google_swe_2", "Google")
+    _write_app_folder(apps_dir, "2026-08-20_acme_swe", "Acme")
+
+    monkeypatch.setattr(application, "APPLICATIONS_DIR", apps_dir)
+
+    assert cli._latest_application_pdf() == latest / "Simon_Chen_Resume.pdf"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from worksisyphus.db import (
     export_profile_json,
     get_audit_history,
@@ -407,4 +409,111 @@ def test_evaluation_round_trips_through_seed(tmp_path: Path) -> None:
     before = conn.execute("SELECT count(*) FROM audit_events").fetchone()[0]
     seed_database(conn, profile_path=profile_file, applications_dir=apps)
     assert conn.execute("SELECT count(*) FROM audit_events").fetchone()[0] == before
+    conn.close()
+
+
+def _insert_app_row(conn, app_id: str, company: str = "Acme", status: str = "applied") -> None:
+    conn.execute(
+        """
+        INSERT INTO applications (id, company, role, date, source_url, status, jd_text, plan_json, evaluation_json)
+        VALUES (?, ?, '', ?, '', ?, '', '{}', '')
+        """,
+        (app_id, company, app_id.split("_", 1)[0], status),
+    )
+
+
+def test_db_status_update_matches_the_filesystem_resolver() -> None:
+    """The old SQL LIKE treated '_' as a wildcard; resolution must mirror the FS grammar exactly."""
+    from worksisyphus.db import update_application_status_in_db
+
+    conn = get_connection(":memory:")
+    init_schema(conn)
+    _insert_app_row(conn, "2026-08-01_acme_swe")
+    _insert_app_row(conn, "2026-08-01_acme_xswe")
+
+    # "swe" stem-matches only acme_swe on disk; LIKE would also have matched acme_xswe.
+    app_id, _, new_status = update_application_status_in_db(conn, "swe", "phone_screen")
+    assert (app_id, new_status) == ("2026-08-01_acme_swe", "phone_screen")
+
+    # LIKE metacharacters in identifiers are literal text and match nothing.
+    with pytest.raises(FileNotFoundError):
+        update_application_status_in_db(conn, "%", "phone_screen")
+    conn.close()
+
+
+def test_db_status_update_lists_ambiguous_matches_multi_line() -> None:
+    from worksisyphus.db import update_application_status_in_db
+
+    conn = get_connection(":memory:")
+    init_schema(conn)
+    _insert_app_row(conn, "2026-08-02_google_data-engineer", company="Google", status="rejected")
+    _insert_app_row(conn, "2026-08-08_google_data-engineer", company="Google", status="applied")
+
+    with pytest.raises(ValueError, match="ambiguous") as excinfo:
+        update_application_status_in_db(conn, "google_data-engineer", "phone_screen")
+    message = excinfo.value.args[0]
+    assert "  2026-08-02_google_data-engineer" in message
+    assert "  2026-08-08_google_data-engineer" in message
+    conn.close()
+
+
+def test_db_listing_orders_retry_ordinals_numerically() -> None:
+    conn = get_connection(":memory:")
+    init_schema(conn)
+    _insert_app_row(conn, "2026-08-24_google_swe", company="Google")
+    _insert_app_row(conn, "2026-08-24_google_swe_10", company="Google")
+    _insert_app_row(conn, "2026-08-24_google_swe_2", company="Google")
+    _insert_app_row(conn, "2026-07-01_google_swe", company="Google")
+
+    order = [app["folder"] for app in list_applications_from_db(conn)]
+    assert order == [
+        "2026-08-24_google_swe",
+        "2026-08-24_google_swe_2",
+        "2026-08-24_google_swe_10",
+        "2026-07-01_google_swe",
+    ]
+    conn.close()
+
+
+def test_seed_deletes_ghost_application_rows_with_audit(tmp_path: Path) -> None:
+    """A DB row whose folder vanished must not survive reseed (partial-restore recovery)."""
+    from worksisyphus.db import seed_database
+
+    conn, profile_file = _seed_fixture(tmp_path)
+    apps = tmp_path / "applications"
+    ghost = apps / "2026-08-01_ghost_swe"
+    ghost.mkdir(parents=True)
+    (ghost / "meta.json").write_text(json.dumps({"company": "Ghost", "status": "applied"}), encoding="utf-8")
+    seed_database(conn, profile_path=profile_file, applications_dir=apps)
+    assert conn.execute("SELECT count(*) FROM applications").fetchone()[0] == 1
+
+    import shutil
+
+    shutil.rmtree(ghost)
+    seed_database(conn, profile_path=profile_file, applications_dir=apps)
+    assert conn.execute("SELECT count(*) FROM applications").fetchone()[0] == 0
+    deletions = conn.execute(
+        "SELECT entity_type, entity_id FROM audit_events WHERE action = 'DELETE'"
+    ).fetchall()
+    assert ("application", "2026-08-01_ghost_swe") in deletions
+
+    # Reseeding unchanged data reports nothing further.
+    before = conn.execute("SELECT count(*) FROM audit_events").fetchone()[0]
+    seed_database(conn, profile_path=profile_file, applications_dir=apps)
+    assert conn.execute("SELECT count(*) FROM audit_events").fetchone()[0] == before
+    conn.close()
+
+
+def test_seed_skips_dot_directories_even_with_meta(tmp_path: Path) -> None:
+    """Staging residue that died after meta-write must never become an application row."""
+    from worksisyphus.db import seed_database
+
+    conn, profile_file = _seed_fixture(tmp_path)
+    apps = tmp_path / "applications"
+    residue = apps / ".staging-abc123"
+    residue.mkdir(parents=True)
+    (residue / "meta.json").write_text(json.dumps({"company": "HalfBuilt", "status": "applied"}), encoding="utf-8")
+
+    seed_database(conn, profile_path=profile_file, applications_dir=apps)
+    assert conn.execute("SELECT count(*) FROM applications").fetchone()[0] == 0
     conn.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -492,9 +492,7 @@ def test_seed_deletes_ghost_application_rows_with_audit(tmp_path: Path) -> None:
     shutil.rmtree(ghost)
     seed_database(conn, profile_path=profile_file, applications_dir=apps)
     assert conn.execute("SELECT count(*) FROM applications").fetchone()[0] == 0
-    deletions = conn.execute(
-        "SELECT entity_type, entity_id FROM audit_events WHERE action = 'DELETE'"
-    ).fetchall()
+    deletions = conn.execute("SELECT entity_type, entity_id FROM audit_events WHERE action = 'DELETE'").fetchall()
     assert ("application", "2026-08-01_ghost_swe") in deletions
 
     # Reseeding unchanged data reports nothing further.


### PR DESCRIPTION
Closes #20.

## What

Four-agent design loop (adversarial reviewer → two designers → synthesis) converged on this spec; implemented and verified against the real 48-application archive.

**Same-day re-application (#20 AC1).** `apply()` no longer raises `FileExistsError` for a second run with the same company/role/date. `_allocate_target` picks the lowest free slot (`_2`, `_3`, ...) and the single `os.replace` publish retries the allocation on `ENOTEMPTY`, so a concurrent apply that claims the slot mid-compile loses microseconds, not a pdflatex run, and published folders are never mutated or consumed. The ordinal grammar is safe by construction: slugify collapses `_` to `-`, and a guard fails loudly if that ever changes.

**One resolver grammar.** `match_application_identifier` (exact match, else unique stem suffix) now drives both `resolve_application_folder` and the DB status update. This removes db.py's `id LIKE '%_<ident>'` query, where `_`/`%` were SQL wildcards — identifier `swe` silently matched `acme_xswe` in the DB but not on disk. Ambiguity errors list every matching full folder name on its own line, copy-pasteable.

**Numeric-aware ordering.** New `application_sort_key`: newest date first, retries in true order within a day (`base, _2, _10` — reverse-lexical put `_10` before `_2`). `_latest_application_pdf` selects max(date, ordinal) instead of `apps[0]`, which under the new within-day ordering would return the *first* plan tried rather than the latest resume delivered.

**Status aggregation (#20 AC3).** Flat table gains an `App#` column: nth application per company chronologically, blank for singletons, grep-safe ASCII. Same-day siblings are separate rows (their statuses diverge fast). Plus `--company <substring>` filter.

**Seed integrity.** `seed_database` skips dot-prefixed staging residue even when it carries a meta.json, and deletes ghost application rows whose folders vanished (this repo's real disaster profile: folders restored from git, DB restored from Turso). Deletion lands inside the seed transaction with a `DELETE` audit event; reseed-stable.

**Lineage: derived, not stored.** No schema change, zero new meta.json fields. Siblings/cycles are computed at read time from folder names + meta company slugs — the only representation that survives partial restores, which is a *normal* event here. Issue's `reapplication_of`/`cycle_year` proposal rejected as YAGNI (dangling-pointer class; zero real cases in 48 apps).

## Deliberate contract changes
- `tests/test_apply_is_immutable`'s same-day `FileExistsError` is superseded by allocation tests (suffix sequence, byte-identical published folder, ENOTEMPTY race, private tex dir).
- `update-status --app` help text drops "unique plan stem" as a guarantee; ambiguity is now loud.
- `evaluate --app` labels reports with the resolved folder name, not the raw identifier.
- Concurrent same-stem applies get private temp tex dirs instead of clobbering shared `tex_files/`.

## Verification
- 138 passed / 2 skipped (canonical-build skips), ruff + mypy clean.
- Live run against the real archive: Google's four applications chain `#1`→`#4`; legacy underscore stems (`bosch_software_engineer_ii`) parse as literal stems.
- No migration needed; Turso push happens via normal sync.

Sequencing note from #28 is satisfied: failure cleanup landed there first, so suffixing only ever disambiguates *published* applications.